### PR TITLE
deform.Form() with use_ajax=True will not use ajax after second submit

### DIFF
--- a/deform/form.py
+++ b/deform/form.py
@@ -63,8 +63,17 @@ class Form(field.Field):
 
        Default options exist even if ``ajax_options`` is not provided.
        By default, ``target`` points at the DOM node representing the
-       form and and ``replaceTarget`` is ``true``.  If you pass these
-       values in ``ajax_options``, the defaults will be overridden.
+       form and and ``replaceTarget`` is ``true``. A successhandler calls
+       the deform_ajaxify method that will ajaxify the newly written form
+       again. the deform_ajaxify method is in the global namespace, it
+       requires a oid, and accepts a method. If it receives a method,
+       it will call the method after it ajaxified the form itself.
+       If you pass these values in ``ajax_options``, the defaults will
+       be overridden.
+       If you want to override the success handler, don't forget to
+       call the original deform_ajaxify successhandler, and pass your
+       own method as an argument. Else, subsequent form submissions
+       won't be submitted via AJAX.
 
        This option has no effect when ``use_ajax`` is False.
 

--- a/deform/templates/form.pt
+++ b/deform/templates/form.pt
@@ -53,22 +53,32 @@
   </fieldset>
 
 <script type="text/javascript" tal:condition="field.use_ajax">
+  function deform_ajaxify(response, status, xhr, form, oid, mthd){
+     var options = {
+       target: '#' + oid,
+       replaceTarget: true,
+       success: function(response, status, xhr, form){
+         deform_ajaxify(response, status, xhr, form, oid);
+       }
+     };
+     var extra_options = ${field.ajax_options};
+     var name;
+     if (extra_options) {
+       for (name in extra_options) {
+         options[name] = extra_options[name];
+       };
+     };
+     $('#' + oid).ajaxForm(options);
+     if(mthd){
+       mthd(response, status, xhr, form);
+     }
+  }
   deform.addCallback(
      '${field.formid}',
-     function(oid) { 
-         var options = {
-           target: '#' + oid,
-           replaceTarget: true,
-         };
-         var extra_options = ${field.ajax_options};
-         var name;
-         if (extra_options) {
-           for (name in extra_options) {
-             options[name] = extra_options[name];
-           };
-         };
-         $('#' + oid).ajaxForm(options);
-   });
+     function(oid) {
+       deform_ajaxify(null, null, null, null, oid);
+     }
+  );
 </script>
-  
+
 </form>


### PR DESCRIPTION
A submit will overwrite the form.
After that there are no event handlers registered any longer to submit the form via ajax.
To reproduce the issue, go to:
http://deformdemo.repoze.org/ajaxform/

and submit the form twice with empty data. the second submit will reload the page.
