### PR TITLE
Use the template loader included with Chameleon

### DIFF
--- a/deform/template.py
+++ b/deform/template.py
@@ -1,55 +1,22 @@
-import os
 from pkg_resources import resource_filename
 
-from chameleon.zpt import language
-from chameleon.zpt.template import PageTemplateFile
-
+from chameleon.zpt.loader import TemplateLoader
 from translationstring import ChameleonTranslate
-
 from deform.exception import TemplateError
 
-def cache(func):
-    def load(self, *args):
-        template = self.registry.get(args)
-        if template is None:
-            self.registry[args] = template = func(self, *args)
-        return template
-    return load
 
-class ZPTTemplateLoader(object):
-    """ A Chameleon ZPT template loader """
-    parser = language.Parser()
+class ZPTTemplateLoader(TemplateLoader):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('encoding', 'utf-8')
+        super(ZPTTemplateLoader, self).__init__(*args, **kwargs)
 
-    def __init__(self, search_path=None, auto_reload=True, debug=True,
-                 encoding='utf-8', translate=None):
-        if search_path is None:
-            search_path = []
-        if isinstance(search_path, basestring):
-            search_path = [search_path]
-        self.search_path = search_path
-        self.auto_reload = auto_reload
-        self.debug = debug
-        self.encoding = encoding
-        self.translate = translate
-        self.registry = {}
-        self.notexists = {}
+    def load(self, filename, *args, **kwargs):
+        try:
+            return super(ZPTTemplateLoader, self).load(
+                filename, *args, **kwargs)
+        except ValueError:
+            raise TemplateError(filename)
 
-    @cache
-    def load(self, filename):
-        for path in self.search_path:
-            path = os.path.join(path, filename)
-            if (path in self.notexists) and (not self.auto_reload):
-                raise TemplateError("Can not find template %s" % filename)
-            try:
-                return PageTemplateFile(path, parser=self.parser,
-                                        auto_reload=self.auto_reload,
-                                        debug = self.debug,
-                                        encoding=self.encoding,
-                                        translate=self.translate)
-            except OSError:
-                self.notexists[path] = True
-
-        raise TemplateError("Can not find template %s" % filename)
 
 class ZPTRendererFactory(object):
     """
@@ -100,7 +67,11 @@ class ZPTRendererFactory(object):
         self.loader = loader
 
     def __call__(self, template_name, **kw):
-        return self.loader.load(template_name + '.pt')(**kw)
+        template = self.load(template_name)
+        return template(**kw)
+
+    def load(self, template_name):
+        return self.loader.load(template_name + '.pt')
 
 
 default_dir = resource_filename('deform', 'templates/')


### PR DESCRIPTION
This should work on 1.3 as well, but I've tested only with 2.0.

I have removed some tests, partly because they "knew" too much about the objects under tests, partly because these tests are now anyway the domain of the library in which the template loader now resides (Chameleon proper).
