### PR TITLE
Fix references to repoze.bfg and old URLs in the demo application

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ Next release
   locale (funny, but breaks ``python setup.py compile_catalog`` with an
   UnknownLocale error.)
 
+- Fix references to repoze.bfg and update obsoletes URLs in the demo application
+
 0.9 (2011-03-01)
 ----------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -103,4 +103,4 @@ Contributors
 
 - Chris McDonough, 2011/02/16
 - Patrick Gerken, 2011/02/22
-
+- Jonathan Ballet, 2011/03/03

--- a/deform/field.py
+++ b/deform/field.py
@@ -458,7 +458,7 @@ class Field(object):
 
         The typical usage of ``validate`` in the wild is often
         something like this (at least in terms of code found within
-        the body of a :mod:`repoze.bfg` view function, the particulars
+        the body of a :mod:`pyramid` view function, the particulars
         will differ in your web framework)::
 
           from webob.exc import HTTPFound

--- a/deformdemo/README.txt
+++ b/deformdemo/README.txt
@@ -14,14 +14,14 @@ Running the Demo
   Hereafter ``/path/to/my/venv`` will be referred to as $VENV in steps
   below.
 
-- Install ``repoze.bfg``, ``pygments`` and ``Babel`` into your
+- Install ``Pyramid``, ``pygments`` and ``Babel`` into your
   virtualenv using ``easy_install``::
 
-    $ $VENV/bin/easy_install repoze.bfg pygments Babel
+    $ $VENV/bin/easy_install Pyramid pygments Babel
 
 - Get a checkout of deform::
 
-    $ svn co http://svn.repoze.org/deform/trunk deform
+    $ git clone git://github.com/Pylons/deform.git
 
 - ``cd`` to the newly checked out deform package::
 

--- a/deformdemo/templates/index.pt
+++ b/deformdemo/templates/index.pt
@@ -2,7 +2,7 @@
   <div metal:fill-slot="main">
     <h1>Deform Demo</h1>
     <h3>
-      <a href="http://docs.repoze.org/deform">Deform</a> is an HTML
+      <a href="http://docs.pylonsproject.org/projects/deform/dev/">Deform</a> is an HTML
       form generation system.  Each link below demonstrates a
       capability.
     </h3>
@@ -15,18 +15,18 @@
 
       <p>
         This demo is written using <a
-        href="http://bfg.repoze.org">repoze.bfg</a>. But please note
+        href="http://pylonsproject.org/">Pyramid</a>. But please note
         that Deform does not depend on any particular web framework,
         we just had to write a demo application in
         <i>something</i>. If, for some unfathomable reason, you'd like
         to run this demo application locally, please read the <a
-        href="http://svn.repoze.org/deform/trunk/deformdemo/README.txt"
+        href="https://github.com/Pylons/deform/raw/master/deformdemo/README.txt"
         >README.txt for installation of this application</a>.
       </p>
 
       <p>
         For further information, see
-        the <a href="http://docs.repoze.org/deform">Deform documentation</a>.
+        the <a href="http://docs.pylonsproject.org/projects/deform/dev/">Deform documentation</a>.
       </p>
 
     </div>

--- a/docs/app.rst
+++ b/docs/app.rst
@@ -5,8 +5,8 @@ An example is worth a thousand words.  Here's an example `Pyramid
 <http://pylonsproject.org>`_ application demonstrating how one might use
 :mod:`deform` to render a form.
 
-.. warning:: :mod:`deform` is not dependent on :mod:`Pyramid` at
-   all; we use BFG in the examples below only to facilitate
+.. warning:: :mod:`deform` is not dependent on :mod:`pyramid` at
+   all; we use Pyramid in the examples below only to facilitate
    demonstration of an actual end-to-end working application that uses
    Deform.
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -358,7 +358,7 @@ as the page which serves up the form itself.  For example, the URL
 ``close.png`` image in the ``static/images`` directory in the
 :mod:`deform` package and ``/static/scripts/deform.js`` as
 ``image/png`` content .  How you arrange to do this is dependent on
-your web framework.  It's done in :mod:`Pyramid` imperative
+your web framework.  It's done in :mod:`pyramid` imperative
 configuration via:
 
 .. code-block:: python
@@ -494,7 +494,7 @@ this chapter, visit
 `http://deformdemo.repoze.org/readonly_sequence_of_mappings/
 <http://deformdemo.repoze.org/readonly_sequence_of_mappings/>`_
 
-The application at http://deformdemo.repoze.org is a :mod:`repoze.bfg`
+The application at http://deformdemo.repoze.org is a :mod:`pyramid`
 application which demonstrates most of the features of Deform,
 including most of the widget and data types available for use within
 an application that uses Deform.  

--- a/docs/i18n.rst
+++ b/docs/i18n.rst
@@ -9,9 +9,9 @@ for the purpose of rendering localized error messages.
 See the `Internationalization demo
 <http://deformdemo.repoze.org/i18n/>`_ for an example of how deform
 error and status messages can be localized.  This demonstration uses
-the `internationalization and localization features of repoze.bfg
-<http://docs.repoze.org/bfg/1.3/narr/i18n.html>`_ to render Deform
-error messages into :term:`Chameleon` form renderings.
+the `internationalization and localization features of Pyramid
+<http://docs.pylonsproject.org/projects/pyramid/1.0/narr/i18n.html>`_
+to render Deform error messages into :term:`Chameleon` form renderings.
 
 
 


### PR DESCRIPTION
Hi,

I updated deform to remove all references to repoze.bfg and to the old URLs for the demo website. Hopefully, this was only in the documentation.
