### PR TITLE
Auto deform.load() call

### DIFF
--- a/deform/static/scripts/deform.js
+++ b/deform/static/scripts/deform.js
@@ -1,3 +1,15 @@
+
+/* 
+ * Register a top-level callback to the deform.load() function 
+ * this will be called when the DOM has finished loading. No need
+ * to include the call at the end of the page.
+ */
+$(document).ready(function(){
+    deform.load();
+});
+
+
+
 var deform  = {
     callbacks: [],
 

--- a/deformdemo/templates/form.pt
+++ b/deformdemo/templates/form.pt
@@ -8,11 +8,6 @@
                ><small>(show in context)</small></a>
     </h1>
     <span tal:replace="structure code"/>
-    <script type="text/javascript">
-      jQuery(function() {
-         deform.load();
-         });
-    </script>
   </div>
 </div>
 

--- a/deformdemo/templates/translated_form.pt
+++ b/deformdemo/templates/translated_form.pt
@@ -19,10 +19,5 @@
                ><small>(show in context)</small></a>
     </h1>
     <span tal:replace="structure code"/>
-    <script type="text/javascript">
-      jQuery(function() {
-         deform.load();
-         });
-    </script>
-  </div>
+   </div>
 </div>


### PR DESCRIPTION
Removed the need to call deform.load() within the templates. This is now a jQuery document ready callback inside deform.js
