### PR TITLE
The docs for deform.interfaces.FileUploadTempStore were missing a required attribute.

### DIFF
--- a/deform/interfaces.py
+++ b/deform/interfaces.py
@@ -46,6 +46,12 @@ class FileUploadTempStore(object):
         Same as dict.get.
         """
 
+    def __contains__(self, name):
+        """
+        This should return `True` if we have a value for the
+        name supplied, `False` otherwise.
+        """
+        
     def preview_url(self, name):
         """
         Return the preview URL for the item previously placed into the

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -14,5 +14,7 @@ Deform implementations.
 
    .. automethod:: __setitem__
     
+   .. automethod:: __contains__
+    
    .. automethod:: preview_url
 


### PR DESCRIPTION
The FileUploadWidget does an 'x in tmpstore' check, which fails if **contains** isn't implemented.
