### PR TITLE
Be more flexible with selecting default widgets

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changes
 Next release
 ------------
 
+- Use default widgets for a schema's baseclass if known instead of always
+  falling back to a text widget.
+
 - Deform now includes a ``beautify.css`` (contributed by Ergo^) in its static
   directory, which can be used to make form element styling prettier.
 

--- a/deform/field.py
+++ b/deform/field.py
@@ -227,9 +227,9 @@ class Field(object):
             widget_maker = schema.default_widget_makers.get(
                 self.schema.typ.__class__)
             if widget_maker is None:
-                for (cls, widget) in schema.default_widget_makers.items():
-                    if isinstance(self.schema.type, cls):
-                        widget_maker = widget
+                for (cls, wgt) in schema.default_widget_makers.items():
+                    if isinstance(self.schema.typ, cls):
+                        widget_maker = wgt
                         break
         if widget_maker is None:
             widget_maker = widget.TextInputWidget

--- a/deform/tests/test_field.py
+++ b/deform/tests/test_field.py
@@ -134,6 +134,19 @@ class TestField(unittest.TestCase):
         widget = field.widget
         self.assertEqual(widget.__class__, MappingWidget)
 
+    def test_widget_no_maker_with_derived_from_default_field(self):
+        from deform.widget import SequenceWidget
+        from colander import Sequence
+
+        class CustomSequence(Sequence):
+            pass
+
+        schema = DummySchema() 
+        schema.typ = CustomSequence()
+        field = self._makeOne(schema)
+        widget = field.widget
+        self.assertEqual(widget.__class__, SequenceWidget)
+
     def test_widget_no_maker_no_default_widget_maker(self):
         from deform.widget import TextInputWidget
         schema = DummySchema()


### PR DESCRIPTION
I noticed some unexepcted behaviour from deform: when you customise a colander field you loose the default widget. In our case we were implementing a custom Mapping type, which deform rendered as a text input. To improve this situation a little bit I extended the default widget lookup in deform to check for base classes if no exact match can be found.
