### PR TITLE
Add class 'field' to <li> elements.

### DIFF
--- a/deform/templates/mapping_item.pt
+++ b/deform/templates/mapping_item.pt
@@ -1,7 +1,8 @@
-<li tal:attributes="class field.error and field.widget.error_class"
-    tal:omit-tag="field.widget.hidden"
+<li class="field${field.error and ' ' + field.widget.error_class}"
     title="${field.description}"
-    id="item-${field.oid}" i18n:domain="deform">
+    id="item-${field.oid}"
+    tal:omit-tag="field.widget.hidden"
+    i18n:domain="deform">
   <!-- mapping_item -->
   <label tal:condition="not (field.widget.hidden or
                              field.widget.category == 'structural')"


### PR DESCRIPTION
Always add class 'field' to mapping item elements (in addition to any field error classes).

This makes it possible to style each form element as a "contained" item, e.g. for alignment purposes or other.
