### PR TITLE
Docstring fix

### DIFF
--- a/deform/widget.py
+++ b/deform/widget.py
@@ -470,8 +470,7 @@ class RichTextWidget(TextInputWidget):
     **Attributes/Arguments**
 
     height
-        The size, in rows, of the text input field.  Defaults to
-        240.
+        The height, in pixels, of the text editor.  Defaults to 240.
 
     readonly_template
         The template name used to render the widget in read-only mode.
@@ -490,8 +489,9 @@ class RichTextWidget(TextInputWidget):
         Defaults to ``simple``.
 
     width
-        The size, in pixels, of the editor.  Defaults to
-        640.
+        The width, in pixels, of the editor.  Defaults to 500.
+        The width can also be given as a percentage (e.g. '100%')
+        relative to the width of the enclosing element.
     """
     height = 240
     width = 500


### PR DESCRIPTION
The default width for the RichTextWidget was listed incorrectly in the docstring.

Also, it turns out that TinyMCE accepts relative widths as well.  Specifying width='100%' for RichTextWidgets works well for forms which are contained in elements of defined width.
