### PR TITLE
Typo in form.css.

### DIFF
--- a/deform/static/css/form.css
+++ b/deform/static/css/form.css
@@ -62,7 +62,7 @@ div.deformReplaces {
     background-color: #FFDFDF;
 }
 
-.deform li.error label.desc, .deform p.error, deform h3.errorMsgLbl{
+.deform li.error label.desc, .deform p.error, .deform h3.errorMsgLbl{
     color: #DF0000;
 }
 


### PR DESCRIPTION
This one is mostly trivial, but if you do apply this patch it will turn the "There was a problem with your submission" header red.   That was clearly the original intent — I don’t know whether that’s still the desired effect.

(Let me know if you’d rather not see quite so many piddly typo pull requests.)
