### PR TITLE
Bug fix.  Not all widgets have an error_class attribute.

### DIFF
--- a/deform/templates/mapping_item.pt
+++ b/deform/templates/mapping_item.pt
@@ -1,4 +1,4 @@
-<li class="field${field.error and ' ' + field.widget.error_class}"
+<li class="field${field.error and field.widget.error_class and ' ' + field.widget.error_class}"
     title="${field.description}"
     id="item-${field.oid}"
     tal:omit-tag="field.widget.hidden"


### PR DESCRIPTION
This fixes a bug introduced in 6549ae707e1a4b4b8409cdd78765410d88416e4a.

(Without this rendering of MappingWidgets whose subfield contains an error
fail with "TypeError: cannot concatenate 'str' and 'NoneType' objects".)
