### PR TITLE
Bug fix: Javascript callbacks not called for redisplay of ajaxified forms

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -33,6 +33,10 @@ Next release
 
 - Allow RichText fields to load their editor only after clicking on them
 
+- There is no longer a ``deform_ajaxify`` global javascript function.
+  Instead forms are AJAXified directly by the javascript callback for the
+  form.
+
 0.9.3 (2011-08-10)
 ------------------
 

--- a/deform/form.py
+++ b/deform/form.py
@@ -71,17 +71,14 @@ class Form(field.Field):
 
        Default options exist even if ``ajax_options`` is not provided.
        By default, ``target`` points at the DOM node representing the
-       form and and ``replaceTarget`` is ``true``. A successhandler calls
-       the deform_ajaxify method that will ajaxify the newly written form
-       again. the deform_ajaxify method is in the global namespace, it
-       requires a oid, and accepts a method. If it receives a method,
-       it will call the method after it ajaxified the form itself.
-       If you pass these values in ``ajax_options``, the defaults will
-       be overridden.
-       If you want to override the success handler, don't forget to
-       call the original deform_ajaxify successhandler, and pass your
-       own method as an argument. Else, subsequent form submissions
-       won't be submitted via AJAX.
+       form and and ``replaceTarget`` is ``true``.
+
+       A successhandler calls the ``deform.processCallbacks`` method
+       that will ajaxify the newly written form again.  If you pass
+       these values in ``ajax_options``, the defaults will be
+       overridden.  If you want to override the success handler, don't
+       forget to call ``deform.processCallbacks``, otherwise
+       subsequent form submissions won't be submitted via AJAX.
 
        This option has no effect when ``use_ajax`` is False.
 

--- a/deform/templates/form.pt
+++ b/deform/templates/form.pt
@@ -53,30 +53,19 @@
   </fieldset>
 
 <script type="text/javascript" tal:condition="field.use_ajax">
-  function deform_ajaxify(response, status, xhr, form, oid, mthd){
-     var options = {
-       target: '#' + oid,
-       replaceTarget: true,
-       success: function(response, status, xhr, form){
-         deform_ajaxify(response, status, xhr, form, oid);
-       }
-     };
-     var extra_options = ${field.ajax_options};
-     var name;
-     if (extra_options) {
-       for (name in extra_options) {
-         options[name] = extra_options[name];
-       };
-     };
-     $('#' + oid).ajaxForm(options);
-     if(mthd){
-       mthd(response, status, xhr, form);
-     }
-  }
   deform.addCallback(
      '${field.formid}',
      function(oid) {
-       deform_ajaxify(null, null, null, null, oid);
+       var options = {
+         target: '#' + oid,
+         replaceTarget: true,
+         success: function() {
+           deform.processCallbacks();
+           deform.focusFirstInput();
+         }
+       };
+       var extra_options = ${field.ajax_options} || {};
+       $('#' + oid).ajaxForm($.extend(options, extra_options));
      }
   );
 </script>


### PR DESCRIPTION
Javascript callbacks registered with deform.addCallback were not being called for redisplayed
ajaxified forms.   This means that any fields dependent on javascript (e.g. RichTextWidgets,
DateInputWidget, etc.) did not render correctly when redisplayed via AJAX.

Note that this patch does away with the deform_ajaxify global javascript function.   This may be a bit of a backwards compatibility issue. If that is a deal-breaker, then I suppose a dummy deform_ajaxify could be retained.  (Deform_ajaxify seems unnecessary and a bit awkward.   Also it (the done-away with defrom_ajaxify, that is) is/was broken in that it stores form-specific state in a global function, causing touble if there are multiple forms on a page.)
