### PR TITLE
add css_class to <select>

### DIFF
--- a/deform/templates/select.pt
+++ b/deform/templates/select.pt
@@ -1,6 +1,7 @@
 <select name="${field.name}"
         id="${field.oid}"
-        tal:attributes="size field.widget.size">
+        tal:attributes="size field.widget.size"
+        tal:attributes="class field.widget.css_class">
  <option tal:repeat="(value, description) field.widget.values"
          tal:attributes="selected value == cstruct and 'selected';
                          class field.widget.css_class"


### PR DESCRIPTION
While &lt;option> can optionally take a css_class, I think the widget css should probably be applied to the &lt;select> rather than the &lt;option>

However, an &lt;option> can take styling (though, you wouldn't do it individually and applying the class to the parent &lt;select> probably is still the correct option), I've left the css_class on the &lt;option> tag as well.

Edited - appears you can insert raw html here.
