### PR TITLE
'bind()' required to use tiny mce with ajax forms. 

### DIFF
--- a/deform/templates/richtext.pt
+++ b/deform/templates/richtext.pt
@@ -17,4 +17,7 @@
           });
       }
       );
+$().bind('form.pre.serialize', function(event, $form, options) {
+    tinyMCE.triggerSave();
+}); 
 </script>


### PR DESCRIPTION
Added the followig js callback for tiny mce:
$().bind('form.pre.serialize', function(event, $form, options) {
    tinyMCE.triggerSave();
}); 
If the code is not included text changes won't be submitted.
