### PR TITLE
Change default setting for 'debug' in template renderer

### DIFF
--- a/deform/template.py
+++ b/deform/template.py
@@ -103,7 +103,7 @@ class ZPTRendererFactory(object):
        an interpolated translation.  Default: ``None`` (no translation
        performed).
     """
-    def __init__(self, search_path, auto_reload=True, debug=True,
+    def __init__(self, search_path, auto_reload=True, debug=False,
                  encoding='utf-8', translator=None):
         self.translate = translator
         loader = ZPTTemplateLoader(search_path=search_path,


### PR DESCRIPTION
Having debug set to True by default is not "a good thing" in my opinion and in the worst case is tantamount to a memory leak. After running a Pyramid process for several weeks, I've seen a machine fill up its temporary space with compiled deform Chameleon templates because of this default setting . Chameleon cleans up compiled templates using atexit & in debug mode creates new compiled files for each rendering. What's more there is no simple way to override it from a developer's perspective that I can see, without customizing widget serialization.
