### PR TITLE
Fixed rendering of sequence item "default values" in SequenceWidget

### DIFF
--- a/deform/widget.py
+++ b/deform/widget.py
@@ -988,7 +988,7 @@ class SequenceWidget(Widget):
         # automated testing; finding last node)
         item_field = field.children[0].clone()
         proto = field.renderer(self.item_template, field=item_field,
-                               cstruct=null, parent=field)
+                               cstruct=item_field.schema.serialize(null), parent=field)
         if isinstance(proto, string_types):
             proto = proto.encode('utf-8')
         proto = url_quote(proto)


### PR DESCRIPTION
Code example:
class SequenceItem(colander.Schema):
    name = colander.SchemaNode(colander.String())
    enabled = colander.SchemaNode(colander.Bool(),
        default='true',
        missing=u'')
class Sequence(colander.SequenceSchema):
    items = SequenceItem()
class Schema(colander.Schema):
    name = colander.SchemaNode(colander.String())
    items = Sequence()

schema = Schema()
form = deform.Form(schema, buttons=('submit',))

When I press "Add Items" in browser "Enabled" checkbox is unchecked.

I fix this problem
