### PR TITLE
#83 correction

### DIFF
--- a/deform/templates/dateinput.pt
+++ b/deform/templates/dateinput.pt
@@ -1,7 +1,7 @@
 <span tal:omit-tag="">
     <input type="date"
            name="${field.name}"
-           value="${cstruct}" 
+           value="${cstruct}"
            tal:attributes="size field.widget.size;
                            class field.widget.css_class"
            id="${field.oid}"/>
@@ -9,7 +9,7 @@
       deform.addCallback(
         '${field.oid}',
         function(oid) {
-            $('#' + oid).datepicker({dateFormat: 'yy-mm-dd'});
+        $('#' + oid).datepicker(${options});
         }
       );
     </script>

--- a/deform/tests/test_widget.py
+++ b/deform/tests/test_widget.py
@@ -289,10 +289,20 @@ class TestDateInputWidget(unittest.TestCase):
         result = widget.deserialize(field, '')
         self.assertEqual(result, null)
 
+    def test_options(self):
+        widget = self._makeOne()
+        widget.options['dummy'] = 'dummyvalue'
+        self.assertIn(('dummy', 'dummyvalue'), widget._options().items())
+
 class TestDateTimeInputWidget(TestDateInputWidget):
     def _makeOne(self, **kw):
         from deform.widget import DateTimeInputWidget
         return DateTimeInputWidget(**kw)
+
+    def test_options(self):
+        widget = self._makeOne()
+        widget.options['dummy'] = 'dummyvalue'
+        self.assertIn(('dummy', 'dummyvalue'), widget._options().items())
 
     def test_serialize_with_timezone(self):
         widget = self._makeOne()
@@ -329,7 +339,7 @@ class TestHiddenWidget(unittest.TestCase):
     def _makeOne(self, **kw):
         from deform.widget import HiddenWidget
         return HiddenWidget(**kw)
-    
+
     def test_serialize_null(self):
         from colander import null
         widget = self._makeOne()
@@ -359,7 +369,7 @@ class TestHiddenWidget(unittest.TestCase):
         self.assertEqual(renderer.template, widget.template)
         self.assertEqual(renderer.kw['field'], field)
         self.assertEqual(renderer.kw['cstruct'], cstruct)
-        
+
     def test_deserialize(self):
         widget = self._makeOne()
         field = DummyField()
@@ -969,7 +979,7 @@ class TestDatePartsWidget(unittest.TestCase):
         schema = DummySchema()
         field = DummyField(schema, None)
         widget = self._makeOne()
-        result = widget.deserialize(field, 
+        result = widget.deserialize(field,
                                     {'year':'\t', 'month':'', 'day':''})
         self.assertEqual(result, null)
 
@@ -1172,7 +1182,7 @@ class TestSequenceWidget(unittest.TestCase):
         self.assertEqual(renderer.kw['field'], field)
         self.assertEqual(renderer.kw['cstruct'], [null])
         self.assertEqual(renderer.template, widget.template)
-        
+
     def test_serialize_add_subitem_value(self):
         from colander import null
         renderer = DummyRenderer('abc')
@@ -1421,7 +1431,7 @@ class TestTextAreaCSVWidget(unittest.TestCase):
         field = DummyField()
         widget.handle_error(field, error)
         self.assertEqual(field.error, error)
-        
+
     def test_handle_error_children_have_msgs(self):
         widget = self._makeOne()
         error = DummyInvalid()
@@ -1525,7 +1535,7 @@ class TestTextInputCSVWidget(unittest.TestCase):
         field = DummyField()
         widget.handle_error(field, error)
         self.assertEqual(field.error, error)
-        
+
     def test_handle_error_children_have_msgs(self):
         widget = self._makeOne()
         error = DummyInvalid()
@@ -1568,7 +1578,7 @@ class TestResourceRegistry(unittest.TestCase):
     def test___call___no_requirement(self):
         reg = self._makeOne()
         self.assertRaises(ValueError, reg.__call__, ( ('abc', 'def'), ))
-        
+
     def test___call___no_version(self):
         reg = self._makeOne()
         reg.registry = {'abc':{'123':{'js':(1,2)}}}

--- a/deform/widget.py
+++ b/deform/widget.py
@@ -1,6 +1,6 @@
 import csv
 import random
-import json 
+import json
 
 from colander import Invalid
 from colander import null
@@ -63,7 +63,7 @@ class Widget(object):
         The name of the CSS class attached to various tags in the form
         renderering indicating an error condition for the field
         associated with this widget.  Default: ``error``.
-    
+
     css_class
         The name of the CSS class attached to various tags in
         the form renderering specifying a new class for the field
@@ -328,7 +328,7 @@ class AutocompleteInputWidget(Widget):
 
 class DateInputWidget(Widget):
     """
-    
+
     Renders a JQuery UI date picker widget
     (http://jqueryui.com/demos/datepicker/).  Most useful when the
     schema node is a ``colander.Date`` object.
@@ -352,12 +352,23 @@ class DateInputWidget(Widget):
     readonly_template = 'readonly/textinput'
     size = None
     requirements = ( ('jqueryui', None), )
+    option_defaults = {'dateFormat': 'yy-mm-dd',}
+    options = {}
+
+    def _options(self):
+        options = self.option_defaults.copy()
+        options.update(self.options)
+        return options
 
     def serialize(self, field, cstruct, readonly=False):
         if cstruct in (null, None):
             cstruct = ''
         template = readonly and self.readonly_template or self.template
-        return field.renderer(template, field=field, cstruct=cstruct)
+        options = self._options()
+        return field.renderer(template,
+                              field=field,
+                              cstruct=cstruct,
+                              options=options)
 
     def deserialize(self, field, pstruct):
         if pstruct in ('', null):
@@ -396,11 +407,6 @@ class DateTimeInputWidget(DateInputWidget):
                        'timeFormat': 'hh:mm:ss',
                        'separator': ' '}
     options = {}
-
-    def _options(self):
-        options = self.option_defaults.copy()
-        options.update(self.options)
-        return options
 
     def serialize(self, field, cstruct, readonly=False):
         if cstruct in (null, None):
@@ -466,7 +472,7 @@ class RichTextWidget(TextInputWidget):
     To use this widget the :term:`TinyMCE Editor` library must be
     provided in the page where the widget is rendered. A version of
     :term:`TinyMCE Editor` is included in deform's static directory.
-    
+
 
     **Attributes/Arguments**
 
@@ -490,7 +496,7 @@ class RichTextWidget(TextInputWidget):
         The template name used to render the widget.  Default:
         ``richtext``.
 
-    skin 
+    skin
         The skin for the WYSIWYG editor. Normally only needed if you
         plan to reuse a TinyMCE js from another framework that
         defined a skin.
@@ -869,7 +875,7 @@ class MappingWidget(Widget):
 
     def deserialize(self, field, pstruct):
         error = None
-        
+
         result = {}
 
         if pstruct is null:
@@ -878,7 +884,7 @@ class MappingWidget(Widget):
         for num, subfield in enumerate(field.children):
             name = subfield.name
             subval = pstruct.get(name, null)
-                            
+
             try:
                 result[name] = subfield.deserialize(subval)
             except Invalid as e:
@@ -1227,7 +1233,7 @@ class DatePartsWidget(Widget):
             year = pstruct['year'].strip()
             month = pstruct['month'].strip()
             day = pstruct['day'].strip()
-            
+
             if (not year and not month and not day):
                 return null
 
@@ -1245,7 +1251,7 @@ class TextAreaCSVWidget(Widget):
     Widget used for a sequence of tuples of scalars; allows for
     editing CSV within a text area.  Used with a schema node which is
     a sequence of tuples.
-    
+
     **Attributes/Arguments**
 
     cols
@@ -1285,7 +1291,7 @@ class TextAreaCSVWidget(Widget):
         else:
             template = self.template
         return field.renderer(template, field=field, cstruct=textrows)
-        
+
     def deserialize(self, field, pstruct):
         if pstruct is null:
             return null
@@ -1315,7 +1321,7 @@ class TextInputCSVWidget(Widget):
     Widget used for a tuple of scalars; allows for editing a single
     CSV line within a text input.  Used with a schema node which is a
     tuple composed entirely of scalar values (integers, strings, etc).
-    
+
     **Attributes/Arguments**
 
     template
@@ -1350,7 +1356,7 @@ class TextInputCSVWidget(Widget):
         else:
             template = self.template
         return field.renderer(template, field=field, cstruct=textrow)
-        
+
     def deserialize(self, field, pstruct):
         if pstruct is null:
             return null
@@ -1442,7 +1448,7 @@ class ResourceRegistry(object):
                         result[thing].append(source)
         return result
 
-            
+
 default_resources = {
     'jquery': {
         None:{


### PR DESCRIPTION
Move the _options method of the DateTimeInputWidget to its ancestor DateTimeInput.
Keep two separated options class attributes since they are not used for the same javascript object (datepicker and datetimepicker).
Use the options attribute in the dateinput.pt template.
Add a simple test for the _options method.
Remove trailing whitespaces.
