### PR TITLE
Allow a custom i18n domain to be used for the "Add ${subitem_title}" link of a SequenceWidget

### DIFF
--- a/deform/tests/test_widget.py
+++ b/deform/tests/test_widget.py
@@ -1222,6 +1222,36 @@ class TestSequenceWidget(unittest.TestCase):
         self.assertEqual(renderer.kw['add_subitem_text'].interpolate(),
                          'Yo titel')
 
+    def test_serialize_add_subitem_translates_title_with_default_domain(self):
+        from colander import null
+        # By default, we get a TranslationString whose domain is 'deform'
+        renderer = DummyRenderer('abc')
+        schema = DummySchema()
+        field = DummyField(schema, renderer, {'title': 'titel'})
+        inner = DummyField()
+        field.children=[inner]
+        widget = self._makeOne()
+        widget.add_subitem_text_template = 'Yo ${subitem_title}'
+        widget.serialize(field, null)
+        self.assertEqual(renderer.kw['add_subitem_text'].domain, 'deform')
+
+    def test_serialize_add_subitem_translates_title_with_another_domain(self):
+        from colander import null
+        from translationstring import TranslationStringFactory
+        renderer = DummyRenderer('abc')
+        schema = DummySchema()
+        field = DummyField(schema, renderer, {'title': 'titel'})
+        inner = DummyField()
+        field.children=[inner]
+        widget = self._makeOne()
+        # Here we provide our own TranslationString with a custom domain
+        custom_domain = 'not_deform'
+        _ = TranslationStringFactory(custom_domain)
+        widget.add_subitem_text_template = _('Yo ${subitem_title}')
+        widget.serialize(field, null)
+        self.assertEqual(renderer.kw['add_subitem_text'].domain,
+                         custom_domain)
+
     def test_serialize_add_subitem_translates_description(self):
         from colander import null
         renderer = DummyRenderer('abc')

--- a/deform/widget.py
+++ b/deform/widget.py
@@ -5,6 +5,8 @@ import json
 from colander import Invalid
 from colander import null
 
+from translationstring import TranslationString
+
 from deform.i18n import _
 
 from deform.compat import (
@@ -1033,8 +1035,12 @@ class SequenceWidget(Widget):
             subitem_title=translate(item_field.title),
             subitem_description=translate(item_field.description),
             subitem_name=item_field.name)
-        add_subitem_text = _(self.add_subitem_text_template,
-                             mapping=add_template_mapping)
+        if isinstance(self.add_subitem_text_template, TranslationString):
+            add_subitem_text = self.add_subitem_text_template % \
+                add_template_mapping            
+        else:
+            add_subitem_text = _(self.add_subitem_text_template,
+                                 mapping=add_template_mapping)
         return field.renderer(template,
                               field=field,
                               cstruct=cstruct,


### PR DESCRIPTION
I can provide my own message for "SequenceWidget.add_subitem_text_template". This message is displayed as the "Add ${subitem_title}" link for a sequence schema.

The problem is that this message is inevitably processed under the "deform" i18n domain, as shown in this excerpt of 'SequenceWidget.serialize()' :

```
# '_' is defined in deform.i18n as TranslationStringFactory('deform')
add_subitem_text = _(self.add_subitem_text_template, mapping=add_template_mapping)
```

The attached commit fixes this bug and allows to provide a TranslationString that has a custom i18n domain. For example, I can now do this:

```
_ = TranslationStringFactory('my_app')
msg = _('Click here to add a ${subitem_title}')
widget = SequenceWidget(add_subitem_text_template=msg)
```
