### PR TITLE
Allow SelectWidget to produce <optgroup> HTML tags.

### DIFF
--- a/deform/templates/readonly/select.pt
+++ b/deform/templates/readonly/select.pt
@@ -1,5 +1,16 @@
-<p tal:repeat="(value, description) values" i18n:domain="deform">
-  <span>${description}</span>
-  <em tal:condition="value == cstruct" i18n:translate="">Selected</em>
-  <em tal:condition="value != cstruct" i18n:translate="">Not Selected</em>
-</p>
+<tal:loop tal:repeat="item values" i18n:domain="deform">
+  <tal:if tal:condition="isinstance(item, field.widget.optgroup_class)">
+    <p tal:condition="not field.widget.long_label_generator"
+       class="optgroup">${item.label}</p>
+    <p tal:repeat="(value, description) item.options">
+      <span tal:content="field.widget.long_label_generator and field.widget.long_label_generator(item.label, description) or description"/>
+      <em tal:condition="value == cstruct" i18n:translate="">Selected</em>
+      <em tal:condition="value != cstruct" i18n:translate="">Not Selected</em>
+    </p>
+  </tal:if>
+  <p tal:condition="not isinstance(item, field.widget.optgroup_class)">
+    <span>${item[1]}</span>
+    <em tal:condition="item[0] == cstruct" i18n:translate="">Selected</em>
+    <em tal:condition="item[0] != cstruct" i18n:translate="">Not Selected</em>
+  </p>
+</tal:loop>

--- a/deform/templates/select.pt
+++ b/deform/templates/select.pt
@@ -1,14 +1,27 @@
 <input type="hidden" name="__start__" value="${field.name}:sequence"
   tal:condition="field.widget.multiple" />
-<select name="${field.name}"
-        id="${field.oid}"
-        tal:attributes="size field.widget.size;
-        class field.widget.css_class;
-        multiple field.widget.multiple">
- <option tal:repeat="(value, description) values"
-         tal:attributes="selected (field.widget.multiple and value in cstruct or value == cstruct) and 'selected';
-                         class field.widget.css_class"
-         value="${value}">${description}</option>
+<select tal:attributes="name field.name;
+                        id field.oid;
+                        size field.widget.size;
+                        class field.widget.css_class;
+                        multiple field.widget.multiple">
+  <tal:loop tal:repeat="item values">
+    <optgroup tal:condition="isinstance(item, field.widget.optgroup_class)"
+              tal:attributes="label item.label">
+      <option tal:repeat="(value, description) item.options"
+              tal:attributes="
+                 selected (field.widget.multiple and value in cstruct or value == cstruct) and 'selected';
+                 class field.widget.css_class;
+                 label field.widget.long_label_generator and description;
+                 value value"
+              tal:content="field.widget.long_label_generator and field.widget.long_label_generator(item.label, description) or description"/>
+    </optgroup>
+    <option tal:condition="not isinstance(item, field.widget.optgroup_class)"
+            tal:attributes="
+                 selected (field.widget.multiple and item[0] in cstruct or item[0] == cstruct) and 'selected';
+                class field.widget.css_class;
+                value item[0]">${item[1]}</option>
+  </tal:loop>
 </select>
 <input type="hidden" name="__end__" value="${field.name}:sequence"
   tal:condition="field.widget.multiple" />

--- a/deform/tests/test_widget.py
+++ b/deform/tests/test_widget.py
@@ -1795,6 +1795,16 @@ class TestNormalizeChoices(unittest.TestCase):
         self.assertEqual(self._call(((1, 'description'),)),
                          [('1', 'description')])
 
+    def test_optgroup_and_tuple(self):
+        from deform.widget import OptGroup
+        optgroup = OptGroup('label', (2, 'two'))
+        normalized = self._call(((1, 'description'), optgroup))
+        self.assertEqual(len(normalized), 2)
+        self.assertEqual(normalized[0], ('1', 'description'))
+        self.assertTrue(isinstance(normalized[1], OptGroup))
+        self.assertEqual(normalized[1].label, 'label')
+        self.assertEqual(normalized[1].options, (('2', 'two'), ))
+
 class DummyRenderer(object):
     def __init__(self, result=''):
         self.result = result

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -92,8 +92,12 @@ Widget-Related
 .. autoclass:: CheckboxChoiceWidget
    :members:
 
-.. autoclass:: SelectWidget
+.. autoclass:: OptGroup
    :members:
+
+.. autoclass:: SelectWidget
+.. no ':members:' here if we can avoid it, as it would generate 
+.. a duplicate entry for 'SelectWidget.optgroup_class'.
 
 .. autoclass:: RadioChoiceWidget
    :members:


### PR DESCRIPTION
With the attached patch, it is now possible to display `<optgroup>` HTML tags with `SelectWidget`. The widget accepts a `long_label_generator` attribute/argument that can be used to generate a "label" attribute on the `<option>` tags for very old browsers that do not support the `<optgroup>` tag.

A few notes:
1. There is probably no use-case where one would want to customize the `optgroup_class` attribute/argument. It is there only to make the `OptGroup` class available in the template.
2. With the `:members:` option of the `autoclass` directive, Sphinx automatically generates a line of documentation for `optgroup_class`: "Alias of OptGroup". Because this is rather useless and we already document it ourselves, I removed the `:members:` option. I did not notice any side-effect.
3. I took the liberty of changing the example for the two-tuples in `values`. I find the new example slightly clearer than the previous one (`('true', 'True')`).

Thanks to Jeff Dairiki who provided feedback on my previous attempt and suggested the `OptGroup` class and the `long_label_generator` option.
