### PR TITLE
Give the preview_url method of the tempstore access to the stored item.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Changes
 Next release
 ------------
 
+- Give the preview_url method of the tempstore access to the stored item. [tomster]
 - Fixed remove bug in nested sequences.  See
   https://github.com/Pylons/deform/pull/89
 

--- a/deform/tests/test_widget.py
+++ b/deform/tests/test_widget.py
@@ -1018,7 +1018,7 @@ class TestFileUploadWidget(unittest.TestCase):
         self.assertEqual(result['filename'], 'filename')
         self.assertEqual(result['mimetype'], 'mimetype')
         self.assertEqual(result['size'], 'size')
-        self.assertEqual(result['preview_url'], 'preview_url')
+        self.assertEqual(result['preview_url'], 'http://localhost/filename')
         self.assertEqual(tmpstore[uid], result)
 
     def test_deserialize_file_selected_with_previous_file(self):
@@ -1033,7 +1033,7 @@ class TestFileUploadWidget(unittest.TestCase):
         self.assertEqual(result['filename'], 'filename')
         self.assertEqual(result['mimetype'], 'mimetype')
         self.assertEqual(result['size'], 'size')
-        self.assertEqual(result['preview_url'], 'preview_url')
+        self.assertEqual(result['preview_url'], 'http://localhost/filename')
         self.assertEqual(tmpstore['uid'], result)
 
     def test_deserialize_file_selected_with_previous_file_IE_whole_path(self):
@@ -1049,7 +1049,7 @@ class TestFileUploadWidget(unittest.TestCase):
         self.assertEqual(result['filename'], 'baz.pt')
         self.assertEqual(result['mimetype'], 'mimetype')
         self.assertEqual(result['size'], 'size')
-        self.assertEqual(result['preview_url'], 'preview_url')
+        self.assertEqual(result['preview_url'], 'http://localhost/filename')
         self.assertEqual(tmpstore['uid'], result)
 
 class TestDatePartsWidget(unittest.TestCase):
@@ -1855,7 +1855,7 @@ class DummyField(object):
 
 class DummyTmpStore(dict):
     def preview_url(self, uid):
-        return 'preview_url'
+        return 'http://localhost/%s' % self[uid]['filename']
 
 class DummyUpload(object):
     file = 'fp'

--- a/deform/widget.py
+++ b/deform/widget.py
@@ -1275,14 +1275,14 @@ class FileUploadWidget(Widget):
                     uid = self.random_id()
                     if self.tmpstore.get(uid) is None:
                         data['uid'] = uid
-                        data['preview_url'] = self.tmpstore.preview_url(uid)
                         self.tmpstore[uid] = data
+                        self.tmpstore[uid]['preview_url'] = self.tmpstore.preview_url(uid)
                         break
             else:
                 # a previous file exists
                 data['uid'] = uid
-                data['preview_url'] = self.tmpstore.preview_url(uid)
                 self.tmpstore[uid] = data
+                self.tmpstore[uid]['preview_url'] = self.tmpstore.preview_url(uid)
         else:
             # the upload control had no file selected
             if uid is None:


### PR DESCRIPTION
This allows implementations of that method to base the URL generation on
the actual data, i.e. generate different previews depending on the file
type etc.
