### PR TITLE
Make DateInputWidget use a simple text field (Pylons/deform#101)

### DIFF
--- a/deform/templates/dateinput.pt
+++ b/deform/templates/dateinput.pt
@@ -1,5 +1,5 @@
 <span tal:omit-tag="">
-    <input type="date"
+    <input type="text"
            name="${field.name}"
            value="${cstruct}"
            tal:attributes="size field.widget.size;


### PR DESCRIPTION
input[type=date] is now supported by modern browsers and displays a
native date picker. This makes sense for a native widget, but opens two
datepickers when the jquery UI datepicker is added. Revert to type=text
for now.
