### PR TITLE
Text can appear to the right of a checkbox.

### DIFF
--- a/deform/templates/checkbox.pt
+++ b/deform/templates/checkbox.pt
@@ -3,4 +3,5 @@
        id="${field.oid}"
        tal:attributes="checked cstruct == field.widget.true_val;
                        class field.widget.css_class"/>
-
+<label tal:condition="hasattr(field.schema, 'text')" for="${field.oid}"
+  tal:content="field.schema.text" class="checkbox-label" />


### PR DESCRIPTION
It is traditional. Checkboxes have text to the right of them. To the point
it seems incomplete, like something is missing, if the label isn't there.
It is even hard to click...

I fear there may be some ideology to the lack of this text in Deform.
It certainly would already be there if you thought it important... Of
course I understand that Deform already offers a label that appears on the
top and some help text that may appear below each control. I just think
it would be nice to offer this additional text possibility for checkboxes,
out of the box.

In the implementation, I have chosen a "text" attribute on the schema itself.
The name of the attribute is very negotiable, I just don't have any
better ideas. When the attribute is lacking, the label doesn't appear.

Really hoping you don't have serious objections to this...
