### PR TITLE
Allow RichTextWidget to accept TinyMCE init options 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 Next Release
 ------------
 
+Features
+~~~~~~~~
+
+- ``deform.widget.RichTextWidget`` now accepts a dict/two-tuple ``options`` 
+  for specifying arbitrary options to pass to TinyMCE's ``init`` function.
+  All default options are now part of the class itself (where possible)
+  and can be customised by using ``options``.
+  [davidjb]
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/deform/templates/richtext.pt
+++ b/deform/templates/richtext.pt
@@ -3,6 +3,7 @@
                  skin skin|field.widget.skin;
                  theme theme|field.widget.theme;
                  delayed_load delayed_load|field.widget.delayed_load;
+                 tinymce_options tinymce_options|field.widget.tinymce_options;
                  oid oid|field.oid;
                  name name|field.name;"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n" 
@@ -22,17 +23,9 @@
           jqoid.show();
           jqoid_preload.remove();
           tinyMCE.init({
-            mode: 'exact',
             language: '<tal:block i18n:translate="language-code">en</tal:block>',
-            elements: oid,
-            strict_loading_mode: true,
-            height: '${height}',
-            width: '${width}',
-            skin: '${skin}',
-            theme: '${theme}',
-            theme_advanced_resizing: true,
-            theme_advanced_toolbar_align: 'left',
-            theme_advanced_toolbar_location: 'top'
+            <tal:block condition="tinymce_options">${tinymce_options},</tal:block>
+            elements: oid
           });
           jqoid_preload.unbind('click');
         });

--- a/deform/tests/test_widget.py
+++ b/deform/tests/test_widget.py
@@ -504,6 +504,36 @@ class TestRichTextWidget(TestTextInputWidget):
         from deform.widget import RichTextWidget
         return RichTextWidget(**kw)
 
+    def test_options(self):
+        renderer = DummyRenderer()
+        schema = DummySchema()
+        field = DummyField(schema, renderer)
+        options = {
+            'theme_advanced_buttons1': 'bold,italic,bullist,numlist',
+            'verify_html': True,
+            'element_format': 'html'
+        }
+        widget = self._makeOne(options=options)
+        #Deprecated class-level attributes
+        widget.skin = 'dummy'
+        widget.theme = 'advanced'
+        cstruct = 'abc'
+        widget.serialize(field, cstruct)
+
+        #Default options should be provided
+        result = renderer.kw['tinymce_options']
+        self.assertTrue('"height": 240' in result)
+        self.assertTrue('"width": 500' in result)
+
+        #Deprecated class-level options should still come through
+        self.assertTrue('"skin": "dummy"' in result)
+        self.assertTrue('"theme": "advanced"' in result)
+
+        #Custom options should be set
+        self.assertTrue('"theme_advanced_buttons1": "bold,italic,bullist,numlist"' in result)
+        self.assertTrue('"verify_html": true' in result)
+        self.assertTrue('"element_format": "html"' in result)
+
 class TestCheckboxWidget(unittest.TestCase):
     def _makeOne(self, **kw):
         from deform.widget import CheckboxWidget


### PR DESCRIPTION
The new `options` attribute allows one to configure any arbitrary init options for TinyMCE -- eg any option from http://www.tinymce.com/wiki.php/Configuration.

Option is specified as either a dict-style (or two-tuple) structure of Python values and converted into JSON.  These options are included in the JavaScript template for the widget against the TinyMCE init call.

My only suggestion beyond what's here is whether the existing TinyMCE-specific options on the widget (height, width, theme, skin) should be made to be defined as part of the `options` dict.  Having it all as one structure is more consistent (eg all options can be set in the same place) and makes the template easier to maintain (eg just a set of 'options' to output rather than 4+ individual settings to specify and name).  Backwards compatibility can be maintained by falling back to look for these 4 options where they currently exist as attributes on the widget.  Thoughts?
