### PR TITLE
Fix latex document generation.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -57,10 +57,6 @@ htmlhelp:
 latex:
 	mkdir -p _build/latex _build/doctrees
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) _build/latex
-	cp _static/*.png _build/latex
-	./convert_images.sh
-	cp _static/latex-warning.png _build/latex
-	cp _static/latex-note.png _build/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in _build/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ html_theme_options = dict(github_url='https://github.com/Pylons/deform')
 
 # The name of an image file (within the static path) to place at the top of
 # the sidebar.
-#html_logo = '.static/logo_hi.gif'
+#html_logo = ''
 
 # The name of an image file (within the static path) to use as favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or
@@ -213,7 +213,7 @@ latex_documents = [
 
 # The name of an image file (relative to this directory) to place at the
 # top of the title page.
-latex_logo = '.static/logo_hi.gif'
+#latex_logo = ''
 
 # For "manual" documents, if this is true, then toplevel headings are
 # parts, not chapters.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,8 +59,16 @@ To report bugs, use the `bug tracker
 
 If you've got questions that aren't answered by this documentation, contact
 the `Pylons-discuss maillist
-<http://groups.google.com/group/pylons-discuss>`_ or join the `#pylons IRC
-channel <irc://irc.freenode.net/#pylons>`_.
+<http://groups.google.com/group/pylons-discuss>`_ or join the 
+
+.. only:: not latex
+
+  `#pylons IRC channel <irc://irc.freenode.net/#pylons>`_.
+
+.. only:: latex
+    
+  #pylons IRC channel ``irc://irc.freenode.net/#pylons``.
+
 
 Browse and check out tagged and trunk versions of :mod:`deform` via the
 `deform package on GitHub <https://github.com/Pylons/deform>`_.  To check out


### PR DESCRIPTION
- don't try copying files from not-existent _static/ directory
  - comment-out latex_logo definition and remove references
    to `.static/logo_hi.gif` both from latex_logo and html_logo
  - work-around a buglet in sphinx.writers.latex.LaTeXTranslator
    whose visit_reference method doesn't recognize `irc://...`
    as a URL reference.
