### PR TITLE
Debug-friendly message for invalid tmpstore

### DIFF
--- a/deform/widget.py
+++ b/deform/widget.py
@@ -1466,9 +1466,19 @@ class FileUploadWidget(Widget):
                     uid = self.random_id()
                     if self.tmpstore.get(uid) is None:
                         data['uid'] = uid
-                        self.tmpstore[uid] = data
-                        preview_url = self.tmpstore.preview_url(uid)
-                        self.tmpstore[uid]['preview_url'] = preview_url
+                        try:
+                            # We can face problems if provided storage
+                            # object is invalid:
+                            # >>> self.tmpstore.__setitem__('abc', '1')
+                            # >>> self.tmpstore.__getitem__('abc') is None
+                            # True
+                            self.tmpstore[uid] = data
+                            preview_url = self.tmpstore.preview_url(uid)
+                            self.tmpstore[uid]['preview_url'] = preview_url
+                        except (KeyError, TypeError) as e:
+                            raise ValueError("Failed to use provided file " \
+                                "storage container. Make sure it implements " \
+                                "all methods of FileUploadTempStore interface")
                         break
             else:
                 # a previous file exists


### PR DESCRIPTION
I met some odd bugs when moved from Py3.2 & deform 0.9.5 to VPS with Py3.3 & deform 0.9.6. In my old code I was using FileUploadTempStore() as a tmpstore for form, and somehow this code worked well in Py3.2k (?!). In my new setup I'm getting this error when I'm trying to upload something:

```

Traceback (most recent call last):
 ......
  File "/home/sim/venv/.../*.py", line 51, in mainline
    appstruct = self.myform.validate(controls)
  File "/home/sim/venv/lib/python3.3/site-packages/deform-0.9.6-py3.3.egg/deform/field.py", line 583, in validate
    return self.validate_pstruct(pstruct)
  File "/home/sim/venv/lib/python3.3/site-packages/deform-0.9.6-py3.3.egg/deform/field.py", line 608, in validate_pstruct
    cstruct = self.deserialize(pstruct)
  File "/home/sim/venv/lib/python3.3/site-packages/deform-0.9.6-py3.3.egg/deform/field.py", line 459, in deserialize
    return self.widget.deserialize(self, pstruct)
  File "/home/sim/venv/lib/python3.3/site-packages/deform-0.9.6-py3.3.egg/deform/widget.py", line 1160, in deserialize
    result[name] = subfield.deserialize(subval)
  File "/home/sim/venv/lib/python3.3/site-packages/deform-0.9.6-py3.3.egg/deform/field.py", line 459, in deserialize
    return self.widget.deserialize(self, pstruct)
  File "/home/sim/venv/lib/python3.3/site-packages/deform-0.9.6-py3.3.egg/deform/widget.py", line 1471, in deserialize
    self.tmpstore[uid]['preview_url'] = preview_url
TypeError: 'NoneType' object does not support item assignment
```

Debugging in deform:

```
(Pdb) self.tmpstore.__setitem__('abc', '1')
(Pdb) self.tmpstore.__getitem__('abc') is None
True
(Pdb) {'1': '2'}.get('1')
'2'
```

So, obviously, I'm getting this problem because my tmpstore is invalid. I have added more user-friendly exception because I saw invalid FileUploadTempStore() as a storage container in some other examples as well.
