### PR TITLE
Allow DateInputWidget options to be set with key word args

### DIFF
--- a/deform/widget.py
+++ b/deform/widget.py
@@ -515,6 +515,7 @@ class DateInputWidget(Widget):
 
     def __init__(self, *args, **kwargs):
         self.options = dict(self.default_options)
+        self._update_options_with_kwargs(kwargs)
         Widget.__init__(self, *args, **kwargs)
 
     def serialize(self, field, cstruct, **kw):
@@ -530,6 +531,11 @@ class DateInputWidget(Widget):
         if pstruct in ('', null):
             return null
         return pstruct
+
+    def _update_options_with_kwargs(self, kwargs):
+        option_keys = self.options.keys()
+        kwoptions = dict([ (k, v) for k, v in kwargs.iteritems() if k in option_keys ])
+        self.options.update(kwoptions)
 
 class DateTimeInputWidget(DateInputWidget):
     """


### PR DESCRIPTION
Thought it would be nice to be able to modify the dateFormat option of DateInputWidget by passing it as a keyword arg to **init** (e.g., DateInputWidget(dateFormat='mm/dd/yyyy')).
