### PR TITLE
deform2: Dateparts extraneous div

### DIFF
--- a/deform/templates/dateparts.pt
+++ b/deform/templates/dateparts.pt
@@ -4,32 +4,29 @@
                   name name|field.name;
                   size size|field.widget.size;
                   css_class css_class|field.widget.css_class">
-${field.start_mapping()}
-
-<div class="row">
-    <div class="col-xs-12">
-        <div class="input-group col-xs-3">
-          <span class="input-group-addon" i18n:translate="">Year</span>
-          <input type="text" name="year" value="${year}"
-                 class="span2 form-control ${css_class}"
-                 tal:attributes="size size; maxlength size"
-                 id="${oid}"/>
-        </div>
-        <div class="input-group col-xs-3">
-          <span class="input-group-addon" i18n:translate="">Month</span>
-          <input type="text" name="month" value="${month}"
-                 class="span2 form-control ${css_class}"
-                 tal:attributes="size size; maxlength size"
-                 id="${oid}-month"/>
-        </div>
-        <div class="input-group col-xs-3">
-          <span class="input-group-addon" i18n:translate="">Day</span>
-          <input type="text" name="day" value="${day}"
-                 class="span2 form-control ${css_class}"
-                 tal:attributes="size size; maxlength size"
-                 id="${oid}-day"/>
-        </div>
+  ${field.start_mapping()}
+  <div class="row">
+    <div class="input-group col-xs-3">
+      <span class="input-group-addon" i18n:translate="">Year</span>
+      <input type="text" name="year" value="${year}"
+             class="span2 form-control ${css_class}"
+             tal:attributes="size size; maxlength size"
+             id="${oid}"/>
     </div>
-</div>
-${field.end_mapping()}
+    <div class="input-group col-xs-3">
+      <span class="input-group-addon" i18n:translate="">Month</span>
+      <input type="text" name="month" value="${month}"
+             class="span2 form-control ${css_class}"
+             tal:attributes="size size; maxlength size"
+             id="${oid}-month"/>
+    </div>
+    <div class="input-group col-xs-3">
+      <span class="input-group-addon" i18n:translate="">Day</span>
+      <input type="text" name="day" value="${day}"
+             class="span2 form-control ${css_class}"
+             tal:attributes="size size; maxlength size"
+             id="${oid}-day"/>
+    </div>
+  </div>
+  ${field.end_mapping()}
 </span>


### PR DESCRIPTION
Remove an extraneous `<div class="col-xs-12">` from `dateparts.pt`.

Wrapping the three col-xs-3 columns within the col-xs-12 column results in extra padding to the left of the first input.
