### PR TITLE
deform2: AutocompleteInputWidget - more powerful configuration for typeahead.js

### DIFF
--- a/deform/templates/autocomplete_input.pt
+++ b/deform/templates/autocomplete_input.pt
@@ -12,11 +12,11 @@
                            class string: form-control ${css_class};
                            style style"
            id="${oid}"/>
-    <script tal:condition="field.widget.values" type="text/javascript">
+    <script tal:condition="options" type="text/javascript">
         deform.addCallback(
           '${field.oid}',
           function (oid) {
-              $('#' + oid).typeahead(${options});
+              $('#' + oid).typeahead(${structure: options});
           }
         );
     </script>

--- a/deform/tests/test_widget.py
+++ b/deform/tests/test_widget.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 from deform.compat import (
     text_type,
@@ -222,6 +223,25 @@ class TestMoneyInputWidget(unittest.TestCase):
         result = widget.deserialize(field, pstruct)
         self.assertEqual(result, '1000000.00')
 
+class Test_serialize_js_config(unittest.TestCase):
+    def _makeLiteral(self, js):
+        from deform.widget import literal_js
+        return literal_js(js)
+
+    def _callIt(self, obj):
+        from deform.widget import serialize_js_config
+        return serialize_js_config(obj)
+
+    def test_serialize_literal(self):
+        literal = self._makeLiteral('func()')
+        serialized = self._callIt(literal)
+        self.assertEqual(serialized, 'func()')
+
+    def test_serialize_literal_in_object(self):
+        literal = self._makeLiteral('func()')
+        serialized = self._callIt({'x': literal})
+        self.assertEqual(serialized, '{"x": func()}')
+
 class TestAutocompleteInputWidget(unittest.TestCase):
     def _makeOne(self, **kw):
         from deform.widget import AutocompleteInputWidget
@@ -287,6 +307,49 @@ class TestAutocompleteInputWidget(unittest.TestCase):
                          {"local": [1,2,3,4],
                           "minLength": 1,
                           "limit": 8})
+
+    def test_serialize_dataset(self):
+        import json
+        widget = self._makeOne()
+        dataset = {'local': [5,6,7,8],
+                   'minLength': 2,
+                   }
+        widget.datasets = dataset
+        renderer = DummyRenderer()
+        schema = DummySchema()
+        field = DummyField(schema, renderer=renderer)
+        cstruct = 'abc'
+        widget.serialize(field, cstruct)
+        self.assertEqual(renderer.template, widget.template)
+        self.assertEqual(renderer.kw['field'], field)
+        self.assertEqual(renderer.kw['cstruct'], cstruct)
+        self.assertEqual(json.loads(renderer.kw['options']),
+                         [{"local": [5,6,7,8],
+                           "minLength": 2,
+                           "limit": 8}])
+
+    def test_serialize_warns_if_datasets_and_values(self):
+        widget = self._makeOne()
+        widget.datasets = [{'local': [42]}]
+        widget.values = [9]
+        renderer = DummyRenderer()
+        schema = DummySchema()
+        field = DummyField(schema, renderer=renderer)
+        cstruct = 'abc'
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            widget.serialize(field, cstruct)
+        self.assertEqual(len(w), 1)
+        self.assertTrue(' ignores ' in str(w[0].message))
+
+    def test_serialize_datasets_type_error(self):
+        widget = self._makeOne()
+        widget.datasets = 2
+        renderer = DummyRenderer()
+        schema = DummySchema()
+        field = DummyField(schema, renderer=renderer)
+        cstruct = 'abc'
+        self.assertRaises(TypeError, widget.serialize, field, cstruct)
 
     def test_serialize_not_null_readonly(self):
         widget = self._makeOne()

--- a/deform/widget.py
+++ b/deform/widget.py
@@ -400,8 +400,8 @@ serialize_js_config = JSConfigSerializer().encode
 class AutocompleteInputWidget(Widget):
     """
     Renders an ``<input type="text"/>`` widget which provides
-    autocompletion via a list of values using bootstrap's typeahead plugin
-    http://twitter.github.com/bootstrap/javascript.html#typeahead.
+    autocompletion via a list of values using twitters's typeahead plugin
+    https://github.com/twitter/typeahead.js
 
     **Attributes/Arguments**
 


### PR DESCRIPTION
This adds a ``datasets`` parameter to ``AutocompleteInputWidget`` which can be used as an alternatives to the ``values`` parameter for configuring the typeahead.js plugin.

Basically the value of ``datasets`` (if given) is JSONified and passed directly to the typeahead plugin.  In addition,
a custom JSONifier is used.  The JSONifier respects a ``literal_js`` marker class that can be used to include
hunks of literal javascript within the ``datasets`` parameter.

(A patch to deformdemo with a demo is forthcoming.)