### PR TITLE
deform2: sequence_item.pt fixups

### DIFF
--- a/deform/templates/sequence_item.pt
+++ b/deform/templates/sequence_item.pt
@@ -5,9 +5,9 @@
                  title title|field.title;
                  oid oid|field.oid"
      title="${description}"
-     class="container deformSeqItem ${field.error and error_class or ''} ${field.widget.item_css_class or ''}"
+     class="form-group row deformSeqItem ${field.error and error_class or ''} ${field.widget.item_css_class or ''}"
      i18n:domain="deform">
-  <div class="col-md-11">
+  <div class="col-xs-11">
     <span tal:replace="structure field.serialize(cstruct)"/>
     <tal:errors condition="field.error and not hidden"
                 define="errstr 'error-%s' % oid"
@@ -18,7 +18,7 @@
          i18n:translate="">${msg}</p>
     </tal:errors>
   </div>
-  <div class="col-md-1" style="padding:0">
+  <div class="col-xs-1" style="padding:0">
     <!-- sequence_item -->
     <span class="deformOrderbutton close glyphicon glyphicon-resize-vertical"
           id="${oid}-order"


### PR DESCRIPTION
Here are a couple fix-ups for sequence_item.pt.

The sequence layout still needs further love.  I'm not particularly fond of the 'panel' layout (in particular I find
the panel-head and panel-footer to be ugly) but right now I haven't really got a better suggestion.

Anyhow, this is a start.  This pull addresses:
- 'row' (not 'container') is the class for the column container in bs3
- add 'form-group' class to provide vertical margin between sequence items
- 'col-xs-_' instead of 'col-md-_' so that close button and drag handle always get their own column
