### PR TITLE
deform2: Fix sortable tinymce instances

### DIFF
--- a/deform/templates/sequence.pt
+++ b/deform/templates/sequence.pt
@@ -84,6 +84,21 @@
                    top: pointer.top - offset.top
                  }
 
+                 if(typeof tinyMCE != "undefined"){
+                   $item.find(".tinymce").each(function(i, obj) {
+                     tinyMCE.execCommand('mceRemoveEditor', false, $(obj).attr('id'));
+                   });
+                 }
+
+                 _super($item, container)
+               },
+               onDrop: function($item, container, _super) {
+                 if(typeof tinyMCE != "undefined"){
+                   $item.find(".tinymce").each(function(i, obj) {
+                     tinyMCE.execCommand('mceAddEditor', true, $(obj).attr('id'));
+                   });
+                 }
+                 $(this).sortable("refresh");
                  _super($item, container)
                },
                onDrag: function ($item, position) {


### PR DESCRIPTION
Problem: the tinyMCE editor does not like jQuery-sortable. After changing the order of a sequence item containing a tinyMCE instance the editor will lose its content, instead displaying a grey background with no textarea.

This deals with the problem of having tinymce instances on orderable sequence items by removing the editor `onDragStart` and reapplying `onDrop`.

It does mean that `Sequence.pt` references tinyMCE which is not very elegant. Perhaps a better solution would be for the sequence items or the widgets themselves to subscribe to an event and handle the logic there?
