### PR TITLE
Fixes for boostrap v3.0.3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,10 @@ Next release
     errorMsg                          error-msg
     errorMsgLbl                       error-msg-lbl
 
+- Fix dateparts.pt and datetimeinput.pt for changes in bootstrap v3.0.3.
+  (The culprit is boostrap commit
+  `853b69f <https://github.com/twbs/bootstrap/commit/853b69f2d>`_.)
+
 2.0a2 (2013-10-18)
 ------------------
 

--- a/deform/templates/dateparts.pt
+++ b/deform/templates/dateparts.pt
@@ -6,30 +6,30 @@
                   style style|field.widget.style;">
   ${field.start_mapping()}
   <div class="row">
-    <div class="input-group col-xs-4">
+    <div class="col-xs-4"><div class="input-group">
       <span class="input-group-addon" i18n:translate="">Year</span>
       <input type="text" name="year" value="${year}"
              class="span2 form-control ${css_class or ''}"
              tal:attributes="style style"
              maxlength="4"
              id="${oid}"/>
-    </div>
-    <div class="input-group col-xs-4">
+    </div></div>
+    <div class="col-xs-4"><div class="input-group">
       <span class="input-group-addon" i18n:translate="">Month</span>
       <input type="text" name="month" value="${month}"
              class="span2 form-control ${css_class or ''}"
              tal:attributes="style style"
              maxlength="2"
              id="${oid}-month"/>
-    </div>
-    <div class="input-group col-xs-4">
+    </div></div>
+    <div class="col-xs-4"><div class="input-group">
       <span class="input-group-addon" i18n:translate="">Day</span>
       <input type="text" name="day" value="${day}"
              class="span2 form-control ${css_class or ''}"
              tal:attributes="style style"
              maxlength="2"
              id="${oid}-day"/>
-    </div>
+    </div></div>
   </div>
   ${field.end_mapping()}
 </div>

--- a/deform/templates/datetimeinput.pt
+++ b/deform/templates/datetimeinput.pt
@@ -6,20 +6,20 @@
                   style style|field.widget.style;">
   ${field.start_mapping()}
   <div class="row">
-    <div class="input-group col-xs-6">
+    <div class="col-xs-6"><div class="input-group">
       <span class="input-group-addon" i18n:translate="">Date</span>
       <input type="text" name="date" value="${date}"
              class="span2 form-control ${css_class or ''} hasDatepicker"
              tal:attributes="style style"
              id="${oid}-date"/>
-    </div>
-    <div class="input-group col-xs-6">
+    </div></div>
+    <div class="col-xs-6"><div class="input-group">
       <span class="input-group-addon" i18n:translate="">Time</span>
       <input type="text" name="time" value="${time}"
              class="span2 form-control ${css_class or ''} hasDatepicker"
              tal:attributes="style style"
              id="${oid}-time"/>
-    </div>
+    </div></div>
   </div>
   ${field.end_mapping()}
   <script type="text/javascript">


### PR DESCRIPTION
Bootstrap v3.0.3 has been released.  It breaks the column layouts in `dateparts.pt` and `datetimeinput.pt`.
(The culprit is [this commit](https://github.com/twbs/bootstrap/commit/853b69f2dfe66a839efa6216e9e7c1a530f92f62).)  This fixes that.

At this point I’ll admit that I do not fully understand the motivation for the upstream change, so perhaps this is not the best solution or maybe this is really an upstream bug.

![deform-dateparts-bs-v3 0 3](https://f.cloud.github.com/assets/495018/1698900/09bfe614-5f70-11e3-8845-f922657d50f3.png)
