### PR TITLE
Fixing minor typo in common_needs.rst example

### DIFF
--- a/docs/common_needs.rst
+++ b/docs/common_needs.rst
@@ -98,7 +98,7 @@ schema:
    import colander
 
    from deform import Form
-   from deform.widget import TextInputWidget
+   from deform.widget import TextAreaWidget
 
    class Person(colander.MappingSchema):
        name = colander.SchemaNode(colander.String(),


### PR DESCRIPTION
The widget used in this example is TextAreaWidget, not TextInputWidget.
