### PR TITLE
Handle unexpected types in pstructs gracefully.

### DIFF
--- a/deform/tests/test_widget.py
+++ b/deform/tests/test_widget.py
@@ -2238,3 +2238,6 @@ class DummyUpload(object):
     type = 'mimetype'
     length = 'size'
 
+    def __nonzero__(self):              # pragma: no cover
+        # cgi.FieldStorage for file uploads are falsey
+        return False

--- a/deform/widget.py
+++ b/deform/widget.py
@@ -55,7 +55,7 @@ class _StrippedString(_PossiblyEmptyString):
 
 class _FieldStorage(SchemaType):
     def deserialize(self, node, cstruct):
-        if not cstruct:
+        if cstruct in (null, None, ''):
             return null
         # weak attempt at duck-typing
         if not hasattr(cstruct, 'file'):


### PR DESCRIPTION
Many of the `deserialize` methods of the various widget classes throw unexpected exceptions when fed unexpected types in their `pstruct`.

For example, I have a `CheckedPasswordWidget` in a “create account” form, which, when certain malicious bots mangle the peppercorn encoding, throws an `AttributeError` upon deserialization.  This results in a 500 status to the client (not a disaster, but not ideal), and a traceback emailed to me (a pain).

This PR treats pstructs with an unexpected type as if they were missing.  Essentially, it ignores them.
An alternative approach would be to raise `colander.Invalid` exceptions.  I'm not sure, really, which is the better approach.  (This was the easiest.  I could be convinced to pursue the other if anyone has strong feelings.)
