### PR TITLE
Restore form validation error message removed in deformdemo test fixes

### DIFF
--- a/deform/templates/form.pt
+++ b/deform/templates/form.pt
@@ -33,7 +33,7 @@
     <div class="alert alert-danger" tal:condition="field.error">
       <div class="errorMsgLbl" i18n:translate=""
         >There was a problem with your submission</div>
-      <div class="error-msg-detaol" i18n:translate=""
+      <div class="error-msg-detail" i18n:translate=""
         >Errors have been highlighted below</div>
       <p class="errorMsg">${field.errormsg}</p>
     </div>


### PR DESCRIPTION
See #206
