### PR TITLE
Invalid appstruct declaration in the documentation.

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -311,7 +311,8 @@ data might look like this:
 .. code-block:: python
    :linenos:
 
-    appstruct = [
+    appstruct = {
+        'people' = [
         {
             'name':'keith',
             'age':20,
@@ -320,7 +321,7 @@ data might look like this:
             'name':'fred',
             'age':23,
             },
-        ]
+        ]}
 
 To inject it into the serialized form as the data to be edited, we'd
 pass it in to the :meth:`deform.Field.render` method to get a form


### PR DESCRIPTION
The basic example rendering the given appstruct does not work, appstruct must be a dictionary and not a list otherwise colander will throw the following exception:

Invalid: {'': u'"[{\'age\': 20, \'name\': \'keith\'}, {\'age\': 23, \'name\': \'fred\'}]" is not a mapping type: Does not implement dict-like functionality.'}

I am using colander v1.0b1.
