### PR TITLE
make dateinput work again by using the fixed name "date" as expected by ...

### DIFF
--- a/deform/templates/dateinput.pt
+++ b/deform/templates/dateinput.pt
@@ -6,7 +6,7 @@
       tal:omit-tag="">
   ${field.start_mapping()}
   <input type="${type_name}"
-         name="${name}"
+         name="date"
          value="${cstruct}"
          
          tal:attributes="class string: ${css_class or ''} form-control hasDatepicker;

--- a/deform/templates/dateinput.pt
+++ b/deform/templates/dateinput.pt
@@ -1,5 +1,4 @@
 <div tal:define="css_class css_class|field.widget.css_class;
-                 name name|field.name;
                  oid oid|field.oid;
                  style style|field.widget.style;
                  type_name type_name|field.widget.type_name;"

--- a/deform/templates/datetimeinput.pt
+++ b/deform/templates/datetimeinput.pt
@@ -1,7 +1,6 @@
 <div i18n:domain="deform"
       tal:omit-tag=""
       tal:define="oid oid|field.oid;
-                  name name|field.name;
                   css_class css_class|field.widget.css_class;
                   style style|field.widget.style;">
   ${field.start_mapping()}

--- a/deform/templates/timeinput.pt
+++ b/deform/templates/timeinput.pt
@@ -7,7 +7,7 @@
       tal:omit-tag="">
   ${field.start_mapping()}
   <input type="${type_name}"
-         name="${name}"
+         name="time"
          value="${cstruct}"
          tal:attributes="size size;
                          class string: ${css_class or ''} form-control hasDatepicker;

--- a/deform/templates/timeinput.pt
+++ b/deform/templates/timeinput.pt
@@ -1,6 +1,5 @@
 <span tal:define="size size|field.widget.size;
                   css_class css_class|field.widget.css_class;
-                  name name|field.name;
                   oid oid|field.oid;
                   style style|field.widget.style|None;
                   type_name type_name|field.widget.type_name;"


### PR DESCRIPTION
...the pstruct schema

I don't really understand why the date input was changed from being a simple single input to a mapping, but this change to the template makes it so it actually works.  Without this change you get the following error message:  "Invalid pstruct: {'date': 'Required'}"  (unless, of course, if you happened to name your dateinput field "date")