### PR TITLE
fix select2 placeholders; allow clearing

### DIFF
--- a/deform/templates/select2.pt
+++ b/deform/templates/select2.pt
@@ -69,7 +69,11 @@
    deform.addCallback(
      '${field.oid}',
      function(oid) {
-       $('#' + oid).select2({containerCssClass: 'form-control'});
+       $('#' + oid).select2({
+         containerCssClass: 'form-control',
+         placeholder: "${field.widget.placeholder|""}",
+         allowClear: true
+       });
      }
    );
   </script>

--- a/deform/templates/select2.pt
+++ b/deform/templates/select2.pt
@@ -71,7 +71,7 @@
      function(oid) {
        $('#' + oid).select2({
          containerCssClass: 'form-control',
-         placeholder: "${field.widget.placeholder|""}",
+         placeholder: "${str(field.widget.placeholder).replace('"','\\"')|""}",
          allowClear: true
        });
      }


### PR DESCRIPTION
- works around an issue listed at ivaynberg/select2#1703
- turns on "clearing" (an "X" appears that allows the user
  to clear the current selection and return to the placeholder)