### PR TITLE
Update custom widget example in docs

### DIFF
--- a/docs/widget.rst
+++ b/docs/widget.rst
@@ -374,7 +374,8 @@ get defined as so:
             if cstruct is null:
                 cstruct = u''
             quoted = cgi.escape(cstruct, quote='"')
-            return u'<input type="text" value="%s">' % quoted
+            return ('<input type="text" name="%s" value="%s">' %
+                    (field.name, quoted))
 
 Note that every ``serialize`` method is responsible for returning a
 serialization, no matter whether it is provided data by its caller or
@@ -446,7 +447,8 @@ attached.
         def serialize(self, field, cstruct, readonly=False):
             if cstruct is null:
                 cstruct = u''
-            return '<input type="text" value="%s">' % cgi.escape(cstruct)
+            return ('<input type="text" name="%s" value="%s">' %
+                    (field.name, cgi.escape(cstruct, quote='"')))
 
         def deserialize(self, field, pstruct):
             if pstruct is null:
@@ -489,7 +491,8 @@ class:
         def serialize(self, field, cstruct, readonly=False):
             if cstruct is null:
                 cstruct = u''
-            return '<input type="text" value="%s">' % cgi.escape(cstruct)
+            return ('<input type="text" name="%s" value="%s">' %
+                    (field.name, cgi.escape(cstruct, quote='"')))
 
         def deserialize(self, field, pstruct):
             if pstruct is null:


### PR DESCRIPTION
The example for a custom widget in the docs builds an input field like this:

```
return u'<input type="text" value="%s">' % quoted
```

But the `name` property is not set, so no data would be submitted for this field.
