### PR TITLE
check that jquery is loaded before using

### DIFF
--- a/deform/static/scripts/deform.js
+++ b/deform/static/scripts/deform.js
@@ -4,9 +4,11 @@
  * to include the call at the end of the page.
  */
 
-$(document).ready(function(){
-    deform.load();
-});
+if (typeof jQuery !== 'undefined') {
+    $(document).ready(function(){
+        deform.load();
+    });
+}
 
 
 var deform_loaded = false;


### PR DESCRIPTION
solves #156 #211 #215 indirectly

Instead of blindly calling jQuery in `deform.js`, first test that it's loaded before calling.  This way you can now postpone loading jQuery until the end of a document and then make your own call to `$(document).ready(function(){ deform.load(); });`.  Without this change, the forced call to jQuery simply throws an error and no further javascript is processed.
