### PR TITLE
Fix misset style in checked_password.pt

### DIFF
--- a/deform/templates/checked_password.pt
+++ b/deform/templates/checked_password.pt
@@ -2,7 +2,7 @@
       tal:define="oid oid|field.oid;
                   name name|field.name;
                   css_class css_class|field.widget.css_class;
-                  style css_class|field.widget.style">
+                  style style|field.widget.style">
 ${field.start_mapping()}
 <div>
   <input type="password"


### PR DESCRIPTION
Corrects issue where prior commit would incorrectly define 'style' to equal 'css_class' instead of that of style|field.widget.style
