### PR TITLE
added `category='structural'` to SequenceWidget

### DIFF
--- a/deform/widget.py
+++ b/deform/widget.py
@@ -1462,6 +1462,7 @@ class SequenceWidget(Widget):
     min_len = None
     max_len = None
     orderable = False
+    category = 'structural'
     requirements = (('deform', None), ('sortable', None))
 
     def prototype(self, field):


### PR DESCRIPTION
According to the docstring on Widget:

> However, if the default
> mapping widget encounters a child widget with the category of
> `structural` during rendering (the default mapping and
> sequence widgets are in this category), it omits the title.

The default for a SequenceWidget should be "structural", but
it's missing.

This deals with issue #232
