### PR TITLE
Support custom template properties in ValidationFailure.render

### DIFF
--- a/deform/exception.py
+++ b/deform/exception.py
@@ -26,14 +26,15 @@ class ValidationFailure(Exception):
         self.cstruct = cstruct
         self.error = error
 
-    def render(self):
+    def render(self, **kw):
         """
         Used to reserialize the form in such a way that the user will
-        see error markers in the form HTML.  This method accepts no
-        arguments and returns text representing the HTML of a form
-        rendering.
+        see error markers in the form HTML.
+
+        The ``**kw`` argument allows a caller to pass named arguments
+        that are passed on to the template.
         """
-        return self.field.widget.serialize(self.field, self.cstruct)
+        return self.field.widget.serialize(self.field, self.cstruct, **kw)
 
 class TemplateError(Exception):
     pass

--- a/deform/tests/test_exception.py
+++ b/deform/tests/test_exception.py
@@ -12,12 +12,15 @@ class TestValidationFailure(unittest.TestCase):
         e = self._makeOne(form, cstruct, None)
         result = e.render()
         self.assertEqual(result, cstruct)
+        result = e.render(custom_property='Test')
+        self.assertEqual(result['custom_property'], 'Test')
 
 class DummyForm(object):
     def __init__(self, widget):
         self.widget = widget
     
 class DummyWidget(object):
-    def serialize(self, field, cstruct):
+    def serialize(self, field, cstruct, **kw):
+        cstruct.update(kw)
         return cstruct
     


### PR DESCRIPTION
The `Form.render` method takes additional arguments, which allows to pass custom properties to the template.

E.g.:

```
rendered = form.render(obj_dict, custom_property="My data")
```

Then in the template `form.pt` you can access this property:

```
<p>${custom_property}</p>
```

Unfortunately the `render` method of `ValidationFailure` does not allow to pass additional arguments, so that you can not pass custom properties to the template. The PR fixes this.
