### PR TITLE
Selectable autofocus

### DIFF
--- a/deform/form.py
+++ b/deform/form.py
@@ -118,6 +118,8 @@ class Form(field.Field):
         self.autocomplete = autocomplete
         if autofocus == False:
           autofocus = 'off'
+        else:
+          autofocus = None
         self.autofocus = autofocus
         field.Field.__init__(self, schema, **kw)
         _buttons = []

--- a/deform/form.py
+++ b/deform/form.py
@@ -53,6 +53,16 @@ class Form(field.Field):
         false value, an ``autocomplete='off'`` attribute will be added to the
         form tag.  Default: ``None``.
 
+    autofocus
+        Determines if this form's first input will be focused on page load. 
+        If a form is below the fold on a web page, default behaviour will 
+        cause the first input to be focused and the browser will scroll down 
+        to it. This can be a problem with responsive layouts which may push 
+        forms below the fold on small devices. 
+        Set ``autofocus=False`` to prevent automatic focusing of this form 
+        on page load. If ``autofocus`` is any other value or non existant 
+        the form will have its first element focused on page load.
+
     use_ajax
        If this option is ``True``, the form will use AJAX (actually
        AJAH); when any submit button is clicked, the DOM node related
@@ -100,12 +110,15 @@ class Form(field.Field):
     css_class = 'deform' # bw compat only; pass a widget to override
     def __init__(self, schema, action='', method='POST', buttons=(),
                  formid='deform', use_ajax=False, ajax_options='{}',
-                 autocomplete=None, **kw):
+                 autocomplete=None, autofocus=None, **kw):
         if autocomplete:
             autocomplete = 'on'
         elif autocomplete is not None:
             autocomplete = 'off'
         self.autocomplete = autocomplete
+        if autofocus == False:
+          autofocus = 'off'
+        self.autofocus = autofocus
         field.Field.__init__(self, schema, **kw)
         _buttons = []
         for button in buttons:

--- a/deform/form.py
+++ b/deform/form.py
@@ -53,14 +53,14 @@ class Form(field.Field):
         false value, an ``autocomplete='off'`` attribute will be added to the
         form tag.  Default: ``None``.
 
-    autofocus
+    firstfocus
         Determines if this form's first input will be focused on page load. 
         If a form is below the fold on a web page, default behaviour will 
         cause the first input to be focused and the browser will scroll down 
         to it. This can be a problem with responsive layouts which may push 
         forms below the fold on small devices. 
-        Set ``autofocus=False`` to prevent automatic focusing of this form 
-        on page load. If ``autofocus`` is any other value or non existant 
+        Set ``firstfocus=False`` to prevent automatic focusing of this form 
+        on page load. If ``firstfocus`` is any other value or non existant 
         the form will have its first element focused on page load.
 
     use_ajax
@@ -110,17 +110,17 @@ class Form(field.Field):
     css_class = 'deform' # bw compat only; pass a widget to override
     def __init__(self, schema, action='', method='POST', buttons=(),
                  formid='deform', use_ajax=False, ajax_options='{}',
-                 autocomplete=None, autofocus=None, **kw):
+                 autocomplete=None, firstfocus=None, **kw):
         if autocomplete:
             autocomplete = 'on'
         elif autocomplete is not None:
             autocomplete = 'off'
         self.autocomplete = autocomplete
-        if autofocus == False:
-          autofocus = 'off'
+        if firstfocus == False:
+          firstfocus = 'off'
         else:
-          autofocus = None
-        self.autofocus = autofocus
+          firstfocus = None
+        self.firstfocus = firstfocus
         field.Field.__init__(self, schema, **kw)
         _buttons = []
         for button in buttons:

--- a/deform/static/scripts/deform.js
+++ b/deform/static/scripts/deform.js
@@ -158,22 +158,32 @@ var deform  = {
 
     focusFirstInput: function (el) {
         el = el || document.body;
-        var input = $(el).find(':input')
-          .filter('[id ^= deformField]')
-          .filter('[type != hidden]')
-          .first();
-        if (input) {
-            var raw = input.get(0);
-            if (raw) {
-                if (raw.type === 'text' || raw.type === 'file' || 
-                    raw.type == 'password' || raw.type == 'text' || 
-                    raw.type == 'textarea') { 
-                    if (!input.hasClass("hasDatepicker")) {
-                        input.focus();
+        /* Select all child forms which do not have autofocus=off */
+        var forms = $(el).find('form').filter('[data-autofocus != off]');
+        
+        if(forms.length>0) {
+            /* Select appropriate input candidates from first form */
+            var input = $(forms[0]).find(':input')
+                                   .filter('[id ^= deformField]')
+                                   .filter('[type != hidden]')
+                                   .first();
+          
+            if (input) {
+                /* input.focus() on allowed input type */
+                var raw = input.get(0);
+                if (raw) {
+                    if (raw.type === 'text' || raw.type === 'file' || 
+                        raw.type == 'password' || raw.type == 'text' || 
+                        raw.type == 'textarea') { 
+                        if (!input.hasClass("hasDatepicker")) {
+                            input.focus();
+                        }
                     }
                 }
             }
+
         }
+
     },
 
     randomString: function (length) {

--- a/deform/static/scripts/deform.js
+++ b/deform/static/scripts/deform.js
@@ -158,8 +158,8 @@ var deform  = {
 
     focusFirstInput: function (el) {
         el = el || document.body;
-        /* Select all child forms which do not have autofocus=off */
-        var forms = $(el).find('form').filter('[data-autofocus != off]');
+        /* Select all child forms which do not have firstfocus=off */
+        var forms = $(el).find('form').filter('[data-firstfocus != off]');
         
         if(forms.length>0) {
             /* Select appropriate input candidates from first form */

--- a/deform/templates/form.pt
+++ b/deform/templates/form.pt
@@ -3,6 +3,7 @@
               css_class css_class|string:${field.widget.css_class or field.css_class or ''};
               item_template item_template|field.widget.item_template;
               autocomplete autocomplete|field.autocomplete;
+              autofocus autofocus|field.autofocus;
               title title|field.title;
               errormsg errormsg|field.errormsg;
               description description|field.description;
@@ -13,6 +14,7 @@
               action action|field.action or None;
               method method|field.method;"
   tal:attributes="autocomplete autocomplete;
+                  data-autofocus autofocus;
                   style style;
                   class css_class;
                   action action;"

--- a/deform/templates/form.pt
+++ b/deform/templates/form.pt
@@ -3,7 +3,7 @@
               css_class css_class|string:${field.widget.css_class or field.css_class or ''};
               item_template item_template|field.widget.item_template;
               autocomplete autocomplete|field.autocomplete;
-              autofocus autofocus|field.autofocus;
+              firstfocus firstfocus|field.firstfocus;
               title title|field.title;
               errormsg errormsg|field.errormsg;
               description description|field.description;
@@ -14,7 +14,7 @@
               action action|field.action or None;
               method method|field.method;"
   tal:attributes="autocomplete autocomplete;
-                  data-autofocus autofocus;
+                  data-firstfocus firstfocus;
                   style style;
                   class css_class;
                   action action;"

--- a/deform/tests/test_form.py
+++ b/deform/tests/test_form.py
@@ -74,23 +74,23 @@ class TestForm(unittest.TestCase):
         form = self._makeOne(schema, autocomplete=False)
         self.assertEqual(form.autocomplete, 'off')
 
-    def test_ctor_autofocus_default(self):
+    def test_ctor_firstfocus_default(self):
         schema = DummySchema()
         schema.children = [DummySchema()]
         form = self._makeOne(schema)
-        self.assertEqual(form.autofocus, None)
+        self.assertEqual(form.firstfocus, None)
 
-    def test_ctor_autofocus_False(self):
+    def test_ctor_firstfocus_False(self):
         schema = DummySchema()
         schema.children = [DummySchema()]
-        form = self._makeOne(schema, autofocus=False)
-        self.assertEqual(form.autofocus, 'off')
+        form = self._makeOne(schema, firstfocus=False)
+        self.assertEqual(form.firstfocus, 'off')
 
-    def test_ctor_autofocus_Other(self):
+    def test_ctor_firstfocus_Other(self):
         schema = DummySchema()
         schema.children = [DummySchema()]
-        form = self._makeOne(schema, autofocus='lorem')
-        self.assertEqual(form.autofocus, None)
+        form = self._makeOne(schema, firstfocus='lorem')
+        self.assertEqual(form.firstfocus, None)
 
 class TestIssues(unittest.TestCase):
 

--- a/deform/tests/test_form.py
+++ b/deform/tests/test_form.py
@@ -74,6 +74,24 @@ class TestForm(unittest.TestCase):
         form = self._makeOne(schema, autocomplete=False)
         self.assertEqual(form.autocomplete, 'off')
 
+    def test_ctor_autofocus_default(self):
+        schema = DummySchema()
+        schema.children = [DummySchema()]
+        form = self._makeOne(schema)
+        self.assertEqual(form.autofocus, None)
+
+    def test_ctor_autofocus_False(self):
+        schema = DummySchema()
+        schema.children = [DummySchema()]
+        form = self._makeOne(schema, autofocus=False)
+        self.assertEqual(form.autofocus, 'off')
+
+    def test_ctor_autofocus_Other(self):
+        schema = DummySchema()
+        schema.children = [DummySchema()]
+        form = self._makeOne(schema, autofocus='lorem')
+        self.assertEqual(form.autofocus, None)
+
 class TestIssues(unittest.TestCase):
 
     def test_issue_54(self):


### PR DESCRIPTION
I came across an issue when building a site with a responsive layout. 

The issue is this: 

deform.js runs focusFirstInput() on document.ready().

If a form is below the fold, the browser scrolls to the element which has received focus. This is usually not a problem, as most forms are above the fold. However, responsive layouts can push forms below the fold on small devices. The end result being, a user loads the page and is immediately scrolled down to wherever the form is. 

A solution is to overload the deform.load method, but this doen't work reliably if javascript is loaded asynchronously. The solution I have been using is in this (selectable_autofocus) branch. 

An autofocus parameter was added. Forms can be init-ed with autofocus=False. This will result in a data-autofocus='off' attribute being added to the form. The focusFirstInput() function of deform.js was altered to ignore forms with data-autofocus='off' attributes.

The end result is: 
* Default behaviour is unchanged. 
* A switch is available to turn off automatic focusing on a per-form basis. 
* data-* attributes validate