### PR TITLE
Default to no autofocus

### DIFF
--- a/deform/field.py
+++ b/deform/field.py
@@ -147,7 +147,7 @@ class Field(object):
 
     def __init__(self, schema, renderer=None, counter=None,
                  resource_registry=None, appstruct=colander.null,
-                 parent=None, **kw):
+                 parent=None, autofocus=None, **kw):
         self.counter = counter or itertools.count()
         self.order = next(self.counter)
         self.oid = getattr(schema, 'oid', 'deformField%s' % self.order)
@@ -167,15 +167,21 @@ class Field(object):
         if parent is not None:
             parent = weakref.ref(parent)
         self._parent = parent
+        self.autofocus = autofocus
         self.__dict__.update(kw)
         for child in schema.children:
+            try:
+                autofocus = getattr(child, 'autofocus')
+            else:
+                autofocus = None
             self.children.append(
                 Field(
                     child,
                     renderer=renderer,
                     counter=self.counter,
                     resource_registry=resource_registry,
-                    parent=self,
+                    parent=self, 
+                    autofocus=autofocus, 
                     **kw
                     )
                 )

--- a/deform/field.py
+++ b/deform/field.py
@@ -109,6 +109,11 @@ class Field(object):
         resource_registry
             The :term:`resource registry` associated with this field.
 
+        autofocus
+            Determines if an input element should have the autofocus html 
+            attribute set. If ``autofocus`` is None, False or omitted, the 
+            autofocus attribute is not set. 
+
     *Constructor Arguments*
 
       ``renderer``, ``counter``, ``resource_registry`` and ``appstruct`` are

--- a/deform/field.py
+++ b/deform/field.py
@@ -177,7 +177,7 @@ class Field(object):
         for child in schema.children:
             try:
                 autofocus = getattr(child, 'autofocus')
-            else:
+            except:
                 autofocus = None
             self.children.append(
                 Field(

--- a/deform/static/scripts/deform.js
+++ b/deform/static/scripts/deform.js
@@ -26,7 +26,6 @@ var deform  = {
       $(function() {
         if (!deform_loaded) {
             deform.processCallbacks();
-            deform.focusFirstInput();
             deform_loaded = true;
       }});
     },
@@ -155,26 +154,6 @@ var deform  = {
         oid_node.find('.deform-seq-add').not(oid_node.find('.deform-seq-container .deform-seq-add')).toggle(show_addbutton);
         $lis.find('.deform-order-button').not($lis.find('.deform-seq-container .deform-order-button')).toggle(orderable && has_multiple);
      },
-
-    focusFirstInput: function (el) {
-        el = el || document.body;
-        var input = $(el).find(':input')
-          .filter('[id ^= deformField]')
-          .filter('[type != hidden]')
-          .first();
-        if (input) {
-            var raw = input.get(0);
-            if (raw) {
-                if (raw.type === 'text' || raw.type === 'file' || 
-                    raw.type == 'password' || raw.type == 'text' || 
-                    raw.type == 'textarea') { 
-                    if (!input.hasClass("hasDatepicker")) {
-                        input.focus();
-                    }
-                }
-            }
-        }
-    },
 
     randomString: function (length) {
         var chr='0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';

--- a/deform/templates/autocomplete_input.pt
+++ b/deform/templates/autocomplete_input.pt
@@ -1,14 +1,16 @@
 <span tal:define="name name|field.name;
                   css_class css_class|field.widget.css_class;
                   oid oid|field.oid;
-                  style style|field.widget.style"
+                  style style|field.widget.style; 
+                  autofocus autofocus|field.autofocus;"
       tal:omit-tag="">
     <input type="text"
            name="${name}"
            value="${cstruct}"
            data-provide="typeahead"
            tal:attributes="class string: form-control ${css_class or ''};
-                           style style"
+                           style style; 
+                           autofocus autofocus"
            id="${oid}"/>
     <script tal:condition="field.widget.values" type="text/javascript">
         deform.addCallback(

--- a/deform/templates/checkbox.pt
+++ b/deform/templates/checkbox.pt
@@ -4,13 +4,15 @@
                        true_val true_val|field.widget.true_val;
                        css_class css_class|field.widget.css_class;
                        style style|field.widget.style;
-                       oid oid|field.oid"
+                       oid oid|field.oid; 
+                       autofocus autofocus|field.autofocus;"
            type="checkbox"
            name="${name}" value="${true_val}"
            id="${oid}"
            tal:attributes="checked cstruct == true_val;
                            class css_class;
-                           style style;" />
+                           style style;
+                           autofocus autofocus" />
 
     <span tal:condition="hasattr(field, 'schema') and hasattr(field.schema, 'label')"
           tal:replace="field.schema.label" class="checkbox-label" >

--- a/deform/templates/checked_input.pt
+++ b/deform/templates/checked_input.pt
@@ -3,7 +3,8 @@
                  css_class css_class|field.widget.css_class;
                  style style|field.widget.style;
                  mask mask|field.widget.mask;
-                 mask_placeholder mask_placeholder|field.widget.mask_placeholder;"
+                 mask_placeholder mask_placeholder|field.widget.mask_placeholder; 
+                 autofocus autofocus|field.autofocus;"
      i18n:domain="deform"
      tal:omit-tag="">
   ${field.start_mapping()}
@@ -11,7 +12,8 @@
     <input type="text" name="${name}" value="${cstruct}"
            tal:attributes="style style;
                            class string: form-control ${css_class or ''};
-                           placeholder subject;"
+                           placeholder subject; 
+                           autofocus autofocus"
            id="${oid}"/>
   </div>
   <div>

--- a/deform/templates/checked_password.pt
+++ b/deform/templates/checked_password.pt
@@ -2,14 +2,16 @@
       tal:define="oid oid|field.oid;
                   name name|field.name;
                   css_class css_class|field.widget.css_class;
-                  style style|field.widget.style">
+                  style style|field.widget.style; 
+                  autofocus autofocus|field.autofocus;">
 ${field.start_mapping()}
 <div>
   <input type="password"
          name="${name}"
          value="${field.widget.redisplay and cstruct or ''}"
          tal:attributes="class string: form-control ${css_class or ''};
-                         style style;"
+                         style style;
+                         autofocus autofocus"
          id="${oid}"
          i18n:attributes="placeholder"
          placeholder="Password"/>

--- a/deform/templates/dateinput.pt
+++ b/deform/templates/dateinput.pt
@@ -2,7 +2,8 @@
                  name name|field.name;
                  oid oid|field.oid;
                  style style|field.widget.style;
-                 type_name type_name|field.widget.type_name;"
+                 type_name type_name|field.widget.type_name; 
+                 autofocus autofocus|field.autofocus;"
       tal:omit-tag="">
   ${field.start_mapping()}
   <input type="${type_name}"
@@ -10,7 +11,8 @@
          value="${cstruct}"
          
          tal:attributes="class string: ${css_class or ''} form-control hasDatepicker;
-                         style style"
+                         style style; 
+                         autofocus autofocus"
          id="${oid}"/>
   ${field.end_mapping()}
   <script type="text/javascript">

--- a/deform/templates/dateparts.pt
+++ b/deform/templates/dateparts.pt
@@ -3,14 +3,15 @@
       tal:define="oid oid|field.oid;
                   name name|field.name;
                   css_class css_class|field.widget.css_class;
-                  style style|field.widget.style;">
+                  style style|field.widget.style; 
+                  autofocus autofocus|field.autofocus;">
   ${field.start_mapping()}
   <div class="row">
     <div class="input-group col-xs-4">
       <span class="input-group-addon" i18n:translate="">Year</span>
       <input type="text" name="year" value="${year}"
              class="span2 form-control ${css_class or ''}"
-             tal:attributes="style style"
+             tal:attributes="style style; autofocus autofocus"
              maxlength="4"
              id="${oid}"/>
     </div>

--- a/deform/templates/datetimeinput.pt
+++ b/deform/templates/datetimeinput.pt
@@ -3,14 +3,15 @@
       tal:define="oid oid|field.oid;
                   name name|field.name;
                   css_class css_class|field.widget.css_class;
-                  style style|field.widget.style;">
+                  style style|field.widget.style; 
+                  autofocus autofocus|field.autofocus;">
   ${field.start_mapping()}
   <div class="row">
     <div class="input-group col-xs-6">
       <span class="input-group-addon" i18n:translate="">Date</span>
       <input type="text" name="date" value="${date}"
              class="span2 form-control ${css_class or ''} hasDatepicker"
-             tal:attributes="style style"
+             tal:attributes="style style; autofocus autofocus"
              id="${oid}-date"/>
     </div>
     <div class="input-group col-xs-6">

--- a/deform/templates/file_upload.pt
+++ b/deform/templates/file_upload.pt
@@ -1,7 +1,8 @@
 <div class="deform-file-upload"
      tal:define="oid oid|field.oid;
                  css_class css_class|field.widget.css_class;
-                 style style|field.widget.style">
+                 style style|field.widget.style; 
+                 autofocus autofocus|field.autofocus;">
 
   ${field.start_mapping()}
 
@@ -16,7 +17,8 @@
 
   <input type="file" name="upload" 
          tal:attributes="class css_class;
-                         style style;"
+                         style style;
+                         autofocus autofocus"
          id="${oid}"/>
 
   ${field.end_mapping()}

--- a/deform/templates/moneyinput.pt
+++ b/deform/templates/moneyinput.pt
@@ -3,11 +3,13 @@
                   mask_options mask_options|'{}';
                   style style|field.widget.style;
                   css_class css_class|field.widget.css_class;
-                  style style|field.widget.style|False"
+                  style style|field.widget.style|False; 
+                  autofocus autofocus|field.autofocus;"
       tal:omit-tag="">
     <input type="text" name="${name}" value="${cstruct}" 
            tal:attributes="style style;
-                           class string: form-control ${css_class or ''}"
+                           class string: form-control ${css_class or ''}; 
+                           autofocus autofocus"
            id="${oid}"/>
     <script type="text/javascript">
       deform.addCallback(

--- a/deform/templates/password.pt
+++ b/deform/templates/password.pt
@@ -3,6 +3,7 @@
     name="${name|field.name}" 
     value="${field.widget.redisplay and cstruct or ''}" 
     tal:attributes="style style|field.widget.style;
-                    class string: form-control ${css_class|field.widget.css_class or ''};"
+        class string: form-control ${css_class|field.widget.css_class or ''}; 
+        autofocus autofocus|field.autofocus;"
     id="${oid|field.oid}"/>
 

--- a/deform/templates/richtext.pt
+++ b/deform/templates/richtext.pt
@@ -1,7 +1,8 @@
 <div tal:define="delayed_load delayed_load|field.widget.delayed_load;
                  tinymce_options tinymce_options|field.widget.tinymce_options;
                  oid oid|field.oid;
-                 name name|field.name;"
+                 name name|field.name; 
+                 autofocus autofocus|field.autofocus;"
     xmlns:i18n="http://xml.zope.org/namespaces/i18n" 
     i18n:domain="deform"
     tal:omit-tag="">
@@ -14,7 +15,8 @@
       }
     </style>  
   <textarea id="${oid}" name="${name}" 
-            class='tinymce form-control' tal:content="structure cstruct" />
+      class='tinymce form-control' tal:content="structure cstruct" 
+      tal:attributes="autofocus autofocus"/>
   <span id="${oid}-preload" class="tinymce-preload" 
         tal:content="structure cstruct" />
   <script type="text/javascript">

--- a/deform/templates/select.pt
+++ b/deform/templates/select.pt
@@ -5,7 +5,8 @@
      size size|field.widget.size;
      css_class css_class|field.widget.css_class;
      optgroup_class optgroup_class|field.widget.optgroup_class;
-     multiple multiple|field.widget.multiple;"
+     multiple multiple|field.widget.multiple; 
+     autofocus autofocus|field.autofocus;"
      tal:omit-tag="">
   <input type="hidden" name="__start__" value="${name}:sequence"
          tal:condition="multiple" />
@@ -15,7 +16,8 @@
           class string: form-control ${css_class or ''};
           multiple multiple;
           size size;
-          style style;">
+          style style;
+          autofocus autofocus">
     <tal:loop tal:repeat="item values">
       <optgroup tal:condition="isinstance(item, optgroup_class)"
                 tal:attributes="label item.label">

--- a/deform/templates/select2.pt
+++ b/deform/templates/select2.pt
@@ -4,7 +4,8 @@
      oid oid|field.oid;
      css_class css_class|field.widget.css_class;
      optgroup_class optgroup_class|field.widget.optgroup_class;
-     multiple multiple|field.widget.multiple;"
+     multiple multiple|field.widget.multiple; 
+     autofocus autofocus|field.autofocus;"
      tal:omit-tag="">
 
    <style>
@@ -45,7 +46,8 @@
           class string: form-control ${css_class or ''};
           data-placeholder field.widget.placeholder|None;
           multiple multiple;
-          style style;">
+          style style; 
+          autofocus autofocus">
     <tal:loop tal:repeat="item values">
       <optgroup tal:condition="isinstance(item, optgroup_class)"
                 tal:attributes="label item.label">

--- a/deform/templates/textarea.pt
+++ b/deform/templates/textarea.pt
@@ -3,10 +3,12 @@
                       css_class css_class|field.widget.css_class;
                       oid oid|field.oid;
                       name name|field.name;
-                      style style|field.widget.style"
+                      style style|field.widget.style; 
+                      autofocus autofocus|field.autofocus;"
           tal:attributes="rows rows;
                           cols cols;
                           class string: form-control ${css_class or ''};
-                          style style"
+                          style style; 
+                          autofocus autofocus"
           id="${oid}"
           name="${name}">${cstruct}</textarea>

--- a/deform/templates/textinput.pt
+++ b/deform/templates/textinput.pt
@@ -4,11 +4,13 @@
                   mask mask|field.widget.mask;
                   mask_placeholder mask_placeholder|field.widget.mask_placeholder;
                   style style|field.widget.style;
+                  autofocus autofocus|field.autofocus;
 "
       tal:omit-tag="">
     <input type="text" name="${name}" value="${cstruct}" 
            tal:attributes="class string: form-control ${css_class or ''};
-                           style style"
+                           style style; 
+                           autofocus autofocus"
            id="${oid}"/>
     <script tal:condition="mask" type="text/javascript">
       deform.addCallback(

--- a/deform/templates/timeinput.pt
+++ b/deform/templates/timeinput.pt
@@ -3,7 +3,8 @@
                   name name|field.name;
                   oid oid|field.oid;
                   style style|field.widget.style|None;
-                  type_name type_name|field.widget.type_name;"
+                  type_name type_name|field.widget.type_name;
+                  autofocus autofocus|field.autofocus;"
       tal:omit-tag="">
   ${field.start_mapping()}
   <input type="${type_name}"
@@ -11,7 +12,8 @@
          value="${cstruct}"
          tal:attributes="size size;
                          class string: ${css_class or ''} form-control hasDatepicker;
-                         style style"
+                         style style; 
+                         autofocus autofocus"
          id="${oid}"/>
   ${field.end_mapping()}
   <script type="text/javascript">

--- a/deform/tests/test_field.py
+++ b/deform/tests/test_field.py
@@ -679,15 +679,28 @@ class TestField(unittest.TestCase):
         self.assertEqual(
             result,
             '<input type="hidden" name="__end__" value="name:rename"/>'
-            )
+             )
+
+    def test_autofocus_not_set(self):
+        schema = DummySchema()
+        field = self._makeOne(schema, autofocus=None)
+        self.assertEqual(field.autofocus, None)
+        self.assertNotIn('autofocus', field.render())
+
+    def test_autofocus_set(self):
+        schema = DummySchema()
+        field = self._makeOne(schema, autofocus=True)
+        self.assertEqual(field.autofocus, True)
+        self.assertIn('autofocus', field.render())
 
 class DummyField(object):
     oid = 'oid'
     requirements = ( ('abc', '123'), ('def', '456'))
-    def __init__(self, schema=None, renderer=None, name='name'):
+    def __init__(self, schema=None, renderer=None, name='name', autofocus=None):
         self.schema = schema
         self.renderer = renderer
         self.name = name
+        self.autofocus = autofocus
 
     def clone(self):
         self.cloned = True

--- a/deform/tests/test_template.py
+++ b/deform/tests/test_template.py
@@ -143,4 +143,5 @@ class DummyField(object):
     widget = DummyWidget()
     name = 'name'
     oid = 'oid'
+    autofocus = None
     

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -129,10 +129,10 @@ the class :class:`colander.SchemaNode`, usually in a nested arrangement.
 Each schema node object has a required *type*, an optional *preparer*
 for adjusting data after deserialization, an optional
 *validator* for deserialized prepared data, an optional *default*, an
-optional *missing*, an optional *title*, an optional *description*,
-and a slightly less optional *name*.  It also accepts *arbitrary*
-keyword arguments, which are attached directly as attributes to the
-node instance.
+optional *missing*, an optional *title*, an optional *description*, a 
+slightly less optional *name* and an optional *autofocus*.  It also accepts 
+*arbitrary* keyword arguments, which are attached directly as attributes to 
+the node instance.
 
 The *type* of a schema node indicates its data type (such as
 :class:`colander.Int` or :class:`colander.String`).
@@ -171,6 +171,10 @@ node.  By default, it is a capitalization of the *name*.
 The *description* of a schema node is metadata about a schema node.
 It shows up as a tooltip when someone hovers over the form control(s)
 related to a :term:`field`.  By default, it is empty.
+
+The *autofocus* of a schema node is used to set the autofocus HTML 
+attribute for an input :term:`field`. If *autofocus* is None, False or 
+omitted, the HTML attribute will not be set. 
 
 The name of a schema node that is introduced as a class-level
 attribute of a :class:`colander.MappingSchema`,


### PR DESCRIPTION
This is an alternative to pull request #244 

Commenters on issue #249 have raised the point that changing the default behaviour to not performing any auto-focusing of input elements may be a better approach. From a *mobile first* standpoint, I agree. Removing default auto-focusing is unlikely to break anybody's UI, but on the off-chance, a switch to include the HTML attribute *autofocus* is fairly straight forward to implement.

The function focusFirstInput() has been removed entirely. Default behaviour is to perform no auto-focusing of any input element. The option has been created for the user to set the HTML attribute *autofocus* in the schema for a form.

[The autofocus HTML attribute](http://www.w3.org/TR/html5/forms.html#autofocusing-a-form-control:-the-autofocus-attribute) can be added to an input element by including `autofocus=True` when defining a schema node. For example: 
```python
    ip = colander.SchemaNode(
         colander.String(),
         title='input',
         missing='', 
         autofocus=True
    )
```
This will result in an input element with the *autofocus* attribute set. Eg. 
```html
<input 
    type="text" 
    name="ip"
    value=""
    id="deformField1" 
    class=" form-control " 
    autofocus="True" 
/>
```
If autofocus is None, False or omitted from the schema, the attribute will not be set.

* Behaviour is changed to disable automatic focusing by default
* The autofocus HTML attribute for an element can be (optionally) set in the form's schema

While the *autofocus* attribute has long been supported on desktops (FF 4+, Chrome 5+, IE 10+, Safari 5+, Opera 9.5+), mobile support is patchy (iOS Safari: No, Opera Mini: No, Android Browser 3+, BlackBerry 7+). We could force it by doing something like, 

```javascript
if(!('autofocus' in document.createElement('input'))) {
    // Focus on some element
}
```
but it would probably be better to let the user decide if they want to implement it themselves.