### PR TITLE
Have the button css_class override the default button class

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,6 +41,10 @@ Next release
 - Fixed handling of buttons in nested sequences.
   See https://github.com/Pylons/deform/issues/197
 
+- Have the button css_class override the default button class. This is
+  backwards-incompatible and will require users of css_class to add a
+  btn-default/btn-primary class to the css_class.
+
 2.0a2 (2013-10-18)
 ------------------
 

--- a/deform/form.py
+++ b/deform/form.py
@@ -158,11 +158,11 @@ class Button(object):
 
     css_class
         The name of a CSS class to attach to the button. In the default
-        form rendering, this string will be appended to ``btnText submit``
-        to become part of the ``class`` attribute of the button. For
-        example, if ``css_class`` was ``foobar`` then the resulting default
-        class becomes ``btnText submit foobar``. Default: ``None`` (no
-        additional class).
+        form rendering, this string will replace the default button type
+        (either ``btn-primary`` or ``btn-default``) on the the ``class``
+        attribute of the button. For example, if ``css_class`` was
+        ``btn-danger`` then the resulting default class becomes
+        ``btn btn-danger``. Default: ``None`` (use default class).
     """
     def __init__(self, name='submit', title=None, type='submit', value=None,
                  disabled=False, css_class=None):

--- a/deform/templates/form.pt
+++ b/deform/templates/form.pt
@@ -54,7 +54,7 @@
               id="${formid+button.name}"
               name="${button.name}"
               type="${button.type}"
-              class="btn ${btn_disposition} ${button.css_class}"
+              class="btn ${button.css_class or btn_disposition}"
               value="${button.value}">
           <i tal:condition="btn_icon" class="${btn_icon}"> </i>
           ${button.title}


### PR DESCRIPTION
Deform sets btn-default and btn-primary automatically,
but this doesn’t work nicely if you want to use different
buttons (i.e. btn-warning or btn-dnager).

This is a backward-incompatible change, hopefully
still something allowed in an alpha version.