### PR TITLE
increment the version; it matches last release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ docs_extras = ['Sphinx']
 
 setupkw = dict(
     name='deform',
-    version='2.0a2',
+    version='2.0a3.dev0',
     description='Another form generation library',
     long_description=README + '\n\n' + CHANGES,
     classifiers=[


### PR DESCRIPTION
Basically, setuptools has no way to distinguish between the github repo and the version on PyPi since they have identical version numbers.  I'm suggesting upping the version number from 2.0a2 to 2.0a3.dev0 (PEP440 compliant development version).  Then, when it's time to release you can either change it to 2.0a3 or 2.1 or whatever.