### PR TITLE
selectively add setuptools_git as a setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,10 @@ setupkw = dict(
         },
     )
 
+# if a git repo then add setuptools-git as a setup_requires
+if os.path.isdir(os.path.join(here, '.git')):
+    setupkw['setup_requires'] = ['setuptools_git']
+
 # to update catalogs, use babel and lingua !
 try:
     import babel


### PR DESCRIPTION
@mcdonc seems to want to avoid a blanket addition of `setuptools_git` as a `setup_requires` so I'm suggesting this as a compromise...  This essentially adds it only if there's a `.git` directory.  This avoids the dependency if the person is installing via a pypi package.

The only issue with this is if a person checks out the repo and does a "setup.py install" on it, it will temporarily install `setuptools_git` even though it's not needed.

Issues this solves: #146 Pylons/pyramid#121 Pylons/pyramid#851 Pylons/substanced#32 repoze/repoze.tm2#4  #174 Pylons/substanced#177  Pylons/pyramid#1213 Pylons/pyramid_chameleon#7

As you can see, this keeps coming up over and over and over again.