### PR TITLE
Form focus

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,10 +3,10 @@ Next release
 
 - Changed deform.js:focusFirstInput() to perform selectable input focusing on 
   page load. 
-  Forms have an optional focus_form parameter ('on'|'off')
-  'on': if the form contains an input with manual_focus='on', that input field 
+  Forms have an optional focus parameter ('on'|'off')
+  'on': if the form contains an input with autofocus='on', that input field 
         will receive focus.
-  'on': if the form does not contain an input with manual_focus='on', the first 
+  'on': if the form does not contain an input with autofocus='on', the first 
         input field of the form will receive focus.
   'off' disables focusing for that form.
   Default behaviour is 'on' (unchanged).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,15 @@
 Next release
 ------------
 
+- Changed deform.js:focusFirstInput() to perform selectable input focusing on 
+  page load. 
+  Forms have an optional focus_form parameter ('auto'|'manual'|'off'|omitted)
+  'auto' means the first form's first input field will receive focus.
+  'manual' means the first form's first input field with the manual_focus 
+           parameter set will receive focus.
+  'off' disables focusing for that form.
+  Default behaviour is 'auto' (unchanged).
+
 - Make ``dateinput`` work again by using the fixed name "date" as expected
   by the pstruct schema.  See https://github.com/Pylons/deform/pull/221.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,7 @@
 Next release
 ------------
 
-- Changed deform.js:focusFirstInput() to perform selectable input focusing on 
-  page load. 
+- Removed deform.js:focusFirstInput()
   Forms have an optional focus parameter ('on'|'off')
   'on': if the form contains an input with autofocus='on', that input field 
         will receive focus.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,12 +3,13 @@ Next release
 
 - Changed deform.js:focusFirstInput() to perform selectable input focusing on 
   page load. 
-  Forms have an optional focus_form parameter ('auto'|'manual'|'off'|omitted)
-  'auto' means the first form's first input field will receive focus.
-  'manual' means the first form's first input field with the manual_focus 
-           parameter set will receive focus.
+  Forms have an optional focus_form parameter ('on'|'off')
+  'on': if the form contains an input with manual_focus='on', that input field 
+        will receive focus.
+  'on': if the form does not contain an input with manual_focus='on', the first 
+        input field of the form will receive focus.
   'off' disables focusing for that form.
-  Default behaviour is 'auto' (unchanged).
+  Default behaviour is 'on' (unchanged).
 
 - Make ``dateinput`` work again by using the fixed name "date" as expected
   by the pstruct schema.  See https://github.com/Pylons/deform/pull/221.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -120,3 +120,4 @@ Contributors
 - Charlie Clark, 2013/09/03
 - Calvin Hendryx-Parker, 2013/09/03
 - Cédric Messiant, 2014/06/27
+- Mike Dunne, 2015/05/08

--- a/deform/field.py
+++ b/deform/field.py
@@ -111,9 +111,8 @@ class Field(object):
 
         manual_focus
             If the field's parent form has its ``focus_form`` argument set to 
-            ``manual``, the first field with ``manual_focus`` set will receive 
-            focus on page load. Any non-None value will set ``manual_focus`` to 
-            ``on``.
+            ``manual``, the first field with ``manual_focus`` set to ``on`` 
+            will receive focus on page load.
             Default: ``None``
 
     *Constructor Arguments*
@@ -169,7 +168,11 @@ class Field(object):
         if resource_registry is None:
             resource_registry = self.default_resource_registry
         self.renderer = renderer
-        if manual_focus is not None:
+        if (manual_focus is None 
+            or manual_focus == False 
+            or manual_focus.lower() == 'off'):
+            self.manual_focus = None
+        elif manual_focus == True or manual_focus.lower() == 'on':
             self.manual_focus = 'on'
         else:
             self.manual_focus = None

--- a/deform/field.py
+++ b/deform/field.py
@@ -151,6 +151,16 @@ class Field(object):
     _cstruct = colander.null
     default_renderer = template.default_renderer
     default_resource_registry = widget.default_resource_registry
+    # Allowable input types for automatic focusing
+    focusable_input_types = (
+                type(colander.String()),
+                type(colander.Integer()),
+                type(colander.Decimal()),
+                type(colander.Float()),
+                type(colander.Date()),
+                type(colander.Time()),
+                type(colander.Boolean()))
+    hidden_type = type(HiddenWidget())
 
     def __init__(self, schema, renderer=None, counter=None,
                  resource_registry=None, appstruct=colander.null,
@@ -197,16 +207,6 @@ class Field(object):
         self._parent = parent
         self.__dict__.update(kw)
 
-        # Allowable input types for automatic focusing
-        focusable_input_types = (
-                type(colander.String()),
-                type(colander.Integer()),
-                type(colander.Decimal()),
-                type(colander.Float()),
-                type(colander.Date()),
-                type(colander.Time()),
-                type(colander.Boolean()))
-        hidden_type = type(HiddenWidget())
         first_input_index = -1
         child_count = 0
         focused = False
@@ -214,8 +214,8 @@ class Field(object):
             if (
                     focus == 'on' and 
                     not focused and
-                    type(child.typ) in focusable_input_types and
-                    type(child.widget) != hidden_type and
+                    type(child.typ) in Field.focusable_input_types and
+                    type(child.widget) != Field.hidden_type and
                     not self.have_first_input
                ):
                 first_input_index = child_count

--- a/deform/field.py
+++ b/deform/field.py
@@ -111,7 +111,7 @@ class Field(object):
 
         manual_focus
             If the field's parent form has its ``focus_form`` argument set to 
-            ``manual``, the first field with ``manual_focus`` set to ``on`` 
+            ``on``, the first field with ``manual_focus`` set to ``on`` 
             will receive focus on page load.
             Default: ``None``
 

--- a/deform/field.py
+++ b/deform/field.py
@@ -111,8 +111,8 @@ class Field(object):
             The :term:`resource registry` associated with this field.
 
         autofocus
-            If the field's parent form has its ``focus`` argument set to 
-            ``on``, the first field with ``autofocus`` set to a trueish value 
+            If the field's parent form has its ``focus`` argument set to
+            ``on``, the first field with ``autofocus`` set to a trueish value
             (``on``, ``True``, ``autofocus``) will receive focus on page load.
             Default: ``None``
 
@@ -179,7 +179,7 @@ class Field(object):
         if resource_registry is None:
             resource_registry = self.default_resource_registry
         self.renderer = renderer
-        
+
         # Parameters passed from parent field to child
         if 'focus' in kw:
             focus = kw['focus']
@@ -192,14 +192,14 @@ class Field(object):
 
         if (
                 focus == 'off' or
-                autofocus is None or 
-                autofocus == False or 
+                autofocus is None or
+                autofocus == False or
                 autofocus.lower() == 'off'
            ):
             self.autofocus = None
         else:
             self.autofocus = 'autofocus'
-        
+
         self.resource_registry = resource_registry
         self.children = []
         if parent is not None:
@@ -212,7 +212,7 @@ class Field(object):
         focused = False
         for child in schema.children:
             if (
-                    focus == 'on' and 
+                    focus == 'on' and
                     not focused and
                     type(child.typ) in Field.focusable_input_types and
                     type(child.widget) != Field.hidden_type and
@@ -222,18 +222,11 @@ class Field(object):
                 self.found_first() # Notify ancestors
             try:
                 autofocus = getattr(child, 'autofocus')
-                if (
-                        focused or
-                        autofocus is None or 
-                        autofocus == False or 
-                        autofocus.lower() == 'off'
-                   ):
-                    autofocus = None
-                else:
-                    autofocus = 'autofocus'
-                    focused = True
             except:
                 autofocus = None
+
+            if autofocus is not None:
+                focused = True
 
             kw['have_first_input'] = self.have_first_input
             self.children.append(
@@ -249,9 +242,9 @@ class Field(object):
                 )
             child_count += 1
         if (
-                focus == 'on' and 
-                not focused and 
-                first_input_index != -1 and 
+                focus == 'on' and
+                not focused and
+                first_input_index != -1 and
                 self.have_first_input
            ):
             # User did not set autofocus. Focus on 1st valid input.
@@ -402,7 +395,7 @@ class Field(object):
     def _default_item_css_class(self):
         if not self.name:
             return None
-        
+
         css_class = unicodedata.normalize('NFKD', compat.text_type(self.name)).encode('ascii', 'ignore').decode('ascii')
         css_class = re.sub('[^\w\s-]', '', css_class).strip().lower()
         css_class = re.sub('[-\s]+', '-', css_class)

--- a/deform/field.py
+++ b/deform/field.py
@@ -6,6 +6,7 @@ import re
 import weakref
 
 from chameleon.utils import Markup
+from deform.widget import HiddenWidget
 
 from . import (
     decorator,
@@ -111,8 +112,8 @@ class Field(object):
 
         autofocus
             If the field's parent form has its ``focus`` argument set to 
-            ``on``, the first field with ``autofocus`` set to ``on`` 
-            will receive focus on page load.
+            ``on``, the first field with ``autofocus`` set to a trueish value 
+            (``on``, ``True``, ``autofocus``) will receive focus on page load.
             Default: ``None``
 
     *Constructor Arguments*
@@ -168,25 +169,73 @@ class Field(object):
         if resource_registry is None:
             resource_registry = self.default_resource_registry
         self.renderer = renderer
-        if (autofocus is None 
-            or autofocus == False 
-            or autofocus.lower() == 'off'):
-            self.autofocus = None
-        elif autofocus == True or autofocus.lower() == 'on':
-            self.autofocus = 'on'
+        
+        # Parameters passed from parent field to child
+        if 'focus' in kw:
+            focus = kw['focus']
         else:
+            focus = 'on'
+        if 'have_first_input' in kw:
+            self.have_first_input = kw['have_first_input']
+        else:
+            self.have_first_input = False
+
+        if (
+                focus == 'off' or
+                autofocus is None or 
+                autofocus == False or 
+                autofocus.lower() == 'off'
+           ):
             self.autofocus = None
+        else:
+            self.autofocus = 'autofocus'
+        
         self.resource_registry = resource_registry
         self.children = []
         if parent is not None:
             parent = weakref.ref(parent)
         self._parent = parent
         self.__dict__.update(kw)
+
+        # Allowable input types for automatic focusing
+        focusable_input_types = (
+                type(colander.String()),
+                type(colander.Integer()),
+                type(colander.Decimal()),
+                type(colander.Float()),
+                type(colander.Date()),
+                type(colander.Time()),
+                type(colander.Boolean()))
+        hidden_type = type(HiddenWidget())
+        first_input_index = -1
+        child_count = 0
+        focused = False
         for child in schema.children:
+            if (
+                    focus == 'on' and 
+                    not focused and
+                    type(child.typ) in focusable_input_types and
+                    type(child.widget) != hidden_type and
+                    not self.have_first_input
+               ):
+                first_input_index = child_count
+                self.found_first() # Notify ancestors
             try:
                 autofocus = getattr(child, 'autofocus')
+                if (
+                        focused or
+                        autofocus is None or 
+                        autofocus == False or 
+                        autofocus.lower() == 'off'
+                   ):
+                    autofocus = None
+                else:
+                    autofocus = 'autofocus'
+                    focused = True
             except:
                 autofocus = None
+
+            kw['have_first_input'] = self.have_first_input
             self.children.append(
                 Field(
                     child,
@@ -198,7 +247,22 @@ class Field(object):
                     **kw
                     )
                 )
+            child_count += 1
+        if (
+                focus == 'on' and 
+                not focused and 
+                first_input_index != -1 and 
+                self.have_first_input
+           ):
+            # User did not set autofocus. Focus on 1st valid input.
+            self.children[first_input_index].autofocus = 'autofocus'
         self.set_appstruct(appstruct)
+
+    def found_first(self):
+        """ Set have_first_input of ancestors """
+        self.have_first_input = True
+        if self.parent is not None:
+            self.parent.found_first()
 
     @property
     def parent(self):

--- a/deform/field.py
+++ b/deform/field.py
@@ -109,9 +109,9 @@ class Field(object):
         resource_registry
             The :term:`resource registry` associated with this field.
 
-        manual_focus
-            If the field's parent form has its ``focus_form`` argument set to 
-            ``on``, the first field with ``manual_focus`` set to ``on`` 
+        autofocus
+            If the field's parent form has its ``focus`` argument set to 
+            ``on``, the first field with ``autofocus`` set to ``on`` 
             will receive focus on page load.
             Default: ``None``
 
@@ -153,7 +153,7 @@ class Field(object):
 
     def __init__(self, schema, renderer=None, counter=None,
                  resource_registry=None, appstruct=colander.null,
-                 parent=None, manual_focus=None, **kw):
+                 parent=None, autofocus=None, **kw):
         self.counter = counter or itertools.count()
         self.order = next(self.counter)
         self.oid = getattr(schema, 'oid', 'deformField%s' % self.order)
@@ -168,14 +168,14 @@ class Field(object):
         if resource_registry is None:
             resource_registry = self.default_resource_registry
         self.renderer = renderer
-        if (manual_focus is None 
-            or manual_focus == False 
-            or manual_focus.lower() == 'off'):
-            self.manual_focus = None
-        elif manual_focus == True or manual_focus.lower() == 'on':
-            self.manual_focus = 'on'
+        if (autofocus is None 
+            or autofocus == False 
+            or autofocus.lower() == 'off'):
+            self.autofocus = None
+        elif autofocus == True or autofocus.lower() == 'on':
+            self.autofocus = 'on'
         else:
-            self.manual_focus = None
+            self.autofocus = None
         self.resource_registry = resource_registry
         self.children = []
         if parent is not None:
@@ -184,9 +184,9 @@ class Field(object):
         self.__dict__.update(kw)
         for child in schema.children:
             try:
-                manual_focus = getattr(child, 'manual_focus')
+                autofocus = getattr(child, 'autofocus')
             except:
-                manual_focus = None
+                autofocus = None
             self.children.append(
                 Field(
                     child,
@@ -194,7 +194,7 @@ class Field(object):
                     counter=self.counter,
                     resource_registry=resource_registry,
                     parent=self,
-                    manual_focus=manual_focus,
+                    autofocus=autofocus,
                     **kw
                     )
                 )

--- a/deform/field.py
+++ b/deform/field.py
@@ -109,6 +109,13 @@ class Field(object):
         resource_registry
             The :term:`resource registry` associated with this field.
 
+        manual_focus
+            If the field's parent form has its ``focus_form`` argument set to 
+            ``manual``, the first field with ``manual_focus`` set will receive 
+            focus on page load. Any non-None value will set ``manual_focus`` to 
+            ``on``.
+            Default: ``None``
+
     *Constructor Arguments*
 
       ``renderer``, ``counter``, ``resource_registry`` and ``appstruct`` are
@@ -147,7 +154,7 @@ class Field(object):
 
     def __init__(self, schema, renderer=None, counter=None,
                  resource_registry=None, appstruct=colander.null,
-                 parent=None, **kw):
+                 parent=None, manual_focus=None, **kw):
         self.counter = counter or itertools.count()
         self.order = next(self.counter)
         self.oid = getattr(schema, 'oid', 'deformField%s' % self.order)
@@ -162,6 +169,10 @@ class Field(object):
         if resource_registry is None:
             resource_registry = self.default_resource_registry
         self.renderer = renderer
+        if manual_focus is not None:
+            self.manual_focus = 'on'
+        else:
+            self.manual_focus = None
         self.resource_registry = resource_registry
         self.children = []
         if parent is not None:
@@ -169,6 +180,10 @@ class Field(object):
         self._parent = parent
         self.__dict__.update(kw)
         for child in schema.children:
+            try:
+                manual_focus = getattr(child, 'manual_focus')
+            except:
+                manual_focus = None
             self.children.append(
                 Field(
                     child,
@@ -176,6 +191,7 @@ class Field(object):
                     counter=self.counter,
                     resource_registry=resource_registry,
                     parent=self,
+                    manual_focus=manual_focus,
                     **kw
                     )
                 )

--- a/deform/form.py
+++ b/deform/form.py
@@ -54,12 +54,12 @@ class Form(field.Field):
         form tag.  Default: ``None``.
 
     focus_form
-        Determines this form's input focus. If ``focus_form`` is ``auto`` or 
+        Determines this form's input focus. If ``focus_form`` is ``on`` or 
         omitted, the first input of the first form on the page will receive 
-        focus on page load. If ``focus_form`` is ``manual``, the first field 
-        with its ``manual_focus`` schema attribute set will receive focus. If 
-        ``focus_form`` is ``off``, no focusing will be done.
-        Default: ``auto``.
+        focus on page load. If ``focus_form`` is ``on``, the first field 
+        with its ``manual_focus`` schema attribute set to ``on`` will receive 
+        focus. If `focus_form`` is ``off``, no focusing will be done.
+        Default: ``on``.
 
     use_ajax
        If this option is ``True``, the form will use AJAX (actually
@@ -108,18 +108,16 @@ class Form(field.Field):
     css_class = 'deform' # bw compat only; pass a widget to override
     def __init__(self, schema, action='', method='POST', buttons=(),
                  formid='deform', use_ajax=False, ajax_options='{}',
-                 autocomplete=None, focus_form='auto', **kw):
+                 autocomplete=None, focus_form='on', **kw):
         if autocomplete:
             autocomplete = 'on'
         elif autocomplete is not None:
             autocomplete = 'off'
         self.autocomplete = autocomplete
-        if focus_form.lower() == 'off':
+        if focus_form.lower() == 'off' or focus_form == False:
             self.focus_form = 'off'
-        elif focus_form.lower() == 'manual':
-            self.focus_form = 'manual'
         else:
-            self.focus_form = 'auto'
+            self.focus_form = 'on'
         field.Field.__init__(self, schema, **kw)
         _buttons = []
         for button in buttons:

--- a/deform/form.py
+++ b/deform/form.py
@@ -57,7 +57,7 @@ class Form(field.Field):
         Determines this form's input focus. If ``focus`` is ``on`` or 
         omitted, the first input of the first form on the page will receive 
         focus on page load. If ``focus`` is ``on``, the first field 
-        with its ``autofocus`` schema attribute set to ``on`` will receive 
+        with its ``autofocus`` schema parameter set to ``on`` will receive 
         focus. If `focus`` is ``off``, no focusing will be done.
         Default: ``on``.
 
@@ -118,6 +118,9 @@ class Form(field.Field):
             self.focus = 'off'
         else:
             self.focus = 'on'
+        # Use kwargs to pass flags to decendant fields; saves cluttering 
+        # the constructor
+        kw['focus'] = self.focus
         field.Field.__init__(self, schema, **kw)
         _buttons = []
         for button in buttons:

--- a/deform/form.py
+++ b/deform/form.py
@@ -53,12 +53,12 @@ class Form(field.Field):
         false value, an ``autocomplete='off'`` attribute will be added to the
         form tag.  Default: ``None``.
 
-    focus_form
-        Determines this form's input focus. If ``focus_form`` is ``on`` or 
+    focus
+        Determines this form's input focus. If ``focus`` is ``on`` or 
         omitted, the first input of the first form on the page will receive 
-        focus on page load. If ``focus_form`` is ``on``, the first field 
-        with its ``manual_focus`` schema attribute set to ``on`` will receive 
-        focus. If `focus_form`` is ``off``, no focusing will be done.
+        focus on page load. If ``focus`` is ``on``, the first field 
+        with its ``autofocus`` schema attribute set to ``on`` will receive 
+        focus. If `focus`` is ``off``, no focusing will be done.
         Default: ``on``.
 
     use_ajax
@@ -108,16 +108,16 @@ class Form(field.Field):
     css_class = 'deform' # bw compat only; pass a widget to override
     def __init__(self, schema, action='', method='POST', buttons=(),
                  formid='deform', use_ajax=False, ajax_options='{}',
-                 autocomplete=None, focus_form='on', **kw):
+                 autocomplete=None, focus='on', **kw):
         if autocomplete:
             autocomplete = 'on'
         elif autocomplete is not None:
             autocomplete = 'off'
         self.autocomplete = autocomplete
-        if focus_form.lower() == 'off' or focus_form == False:
-            self.focus_form = 'off'
+        if focus.lower() == 'off' or focus == False:
+            self.focus = 'off'
         else:
-            self.focus_form = 'on'
+            self.focus = 'on'
         field.Field.__init__(self, schema, **kw)
         _buttons = []
         for button in buttons:

--- a/deform/form.py
+++ b/deform/form.py
@@ -53,6 +53,14 @@ class Form(field.Field):
         false value, an ``autocomplete='off'`` attribute will be added to the
         form tag.  Default: ``None``.
 
+    focus_form
+        Determines this form's input focus. If ``focus_form`` is ``auto`` or 
+        omitted, the first input of the first form on the page will receive 
+        focus on page load. If ``focus_form`` is ``manual``, the first field 
+        with its ``manual_focus`` schema attribute set will receive focus. If 
+        ``focus_form`` is ``off``, no focusing will be done.
+        Default: ``auto``.
+
     use_ajax
        If this option is ``True``, the form will use AJAX (actually
        AJAH); when any submit button is clicked, the DOM node related
@@ -100,12 +108,18 @@ class Form(field.Field):
     css_class = 'deform' # bw compat only; pass a widget to override
     def __init__(self, schema, action='', method='POST', buttons=(),
                  formid='deform', use_ajax=False, ajax_options='{}',
-                 autocomplete=None, **kw):
+                 autocomplete=None, focus_form='auto', **kw):
         if autocomplete:
             autocomplete = 'on'
         elif autocomplete is not None:
             autocomplete = 'off'
         self.autocomplete = autocomplete
+        if focus_form.lower() == 'off':
+            self.focus_form = 'off'
+        elif focus_form.lower() == 'manual':
+            self.focus_form = 'manual'
+        else:
+            self.focus_form = 'auto'
         field.Field.__init__(self, schema, **kw)
         _buttons = []
         for button in buttons:

--- a/deform/static/scripts/deform.js
+++ b/deform/static/scripts/deform.js
@@ -158,38 +158,38 @@ var deform  = {
 
     focusFirstInput: function (el) {
         /*
-         * If a form's data-deform-focus-form attribute is 'off', no focusing 
+         * If a form's data-deform-focus attribute is 'off', no focusing 
          * will be done on that form.
          *
-         * If a form's data-deform-focus-form attribute is 'on' AND a child 
-         * input has its data-deform-manual-focus attribute set to 'on', that 
+         * If a form's data-deform-focus attribute is 'on' AND a child 
+         * input has its data-deform-autofocus attribute set to 'on', that 
          * input will be focused.
          *
-         * If a form's data-deform-focus-form attribute is 'on' AND no child has 
-         * its data-deform-manual-focus attribute set to 'on', the first input 
+         * If a form's data-deform-focus attribute is 'on' AND no child has 
+         * its data-deform-autofocus attribute set to 'on', the first input 
          * of the form will be focused.
          */
         el = el || document.body;
 
-        /* Select the first form which does not have data-deform-focus-form=off */
-        var form = $(el).find('form').filter('[data-deform-focus-form = on]').first();
+        /* Select the first form which does not have data-deform-focus=off */
+        var form = $(el).find('form').filter('[data-deform-focus = on]').first();
 
-        if(form) {
-            /* Focus on the first input with data-deform-manual-focus='on' */
-            var manual_input = $(form).find(':input')
+        if(form.length==1) {
+            /* Focus on the first input with data-deform-autofocus='on' */
+            var autofocus_input = $(form).find(':input')
                 .filter('[id ^= deformField]')
                 .filter('[type != hidden]')
-                .filter('[data-deform-manual-focus = "on"]')
+                .filter('[data-deform-autofocus = "on"]')
                 .first();
             
-            if(manual_input.length==1) {
-                var raw = manual_input.get(0);
+            if(autofocus_input.length==1) {
+                var raw = autofocus_input.get(0);
                 if (raw) {
                     if (raw.type === 'text' || raw.type === 'file' || 
                         raw.type == 'password' || raw.type == 'text' || 
                         raw.type == 'textarea') { 
-                            if (!manual_input.hasClass("hasDatepicker")) {
-                                manual_input.focus();
+                            if (!autofocus_input.hasClass("hasDatepicker")) {
+                                autofocus_input.focus();
                                 return;
                             }
                     }

--- a/deform/static/scripts/deform.js
+++ b/deform/static/scripts/deform.js
@@ -157,44 +157,51 @@ var deform  = {
      },
 
     focusFirstInput: function (el) {
-        /* If the first form on the page has its data-deform-focus-form 
-         * attribute set to 'auto', the first child input will be focused. If 
-         * the attribute is set to 'manual', the first child input with its 
-         * data-deform-manual-focus attribute set will be focused. Otherwise, no 
-         * focusing will be performed. */
+        /*
+         * If a form's data-deform-focus-form attribute is 'off', no focusing 
+         * will be done on that form.
+         *
+         * If a form's data-deform-focus-form attribute is 'on' AND a child 
+         * input has its data-deform-manual-focus attribute set to 'on', that 
+         * input will be focused.
+         *
+         * If a form's data-deform-focus-form attribute is 'on' AND no child has 
+         * its data-deform-manual-focus attribute set to 'on', the first input 
+         * of the form will be focused.
+         */
         el = el || document.body;
 
         /* Select the first form which does not have data-deform-focus-form=off */
-        var form = $(el).find('form').filter('[data-deform-focus-form != off]').first();
+        var form = $(el).find('form').filter('[data-deform-focus-form = on]').first();
 
         if(form) {
-            if($(form).attr('data-deform-focus-form') == 'manual') {
-                /* Focus on the first input with data-deform-manual-focus set */
-                var input = $(form).find(':input')
-                    .filter('[id ^= deformField]')
-                    .filter('[type != hidden]')
-                    .filter('[data-deform-manual-focus = "on"]')
-                    .first();
-                if (input) {
-                    var raw = input.get(0);
-                    if (raw) {
-                        if (raw.type === 'text' || raw.type === 'file' || 
-                            raw.type == 'password' || raw.type == 'text' || 
-                            raw.type == 'textarea') { 
-                                if (!input.hasClass("hasDatepicker")) {
-                                    input.focus();
-                                    return;
-                                }
-                        }
+            /* Focus on the first input with data-deform-manual-focus='on' */
+            var manual_input = $(form).find(':input')
+                .filter('[id ^= deformField]')
+                .filter('[type != hidden]')
+                .filter('[data-deform-manual-focus = "on"]')
+                .first();
+            
+            if(manual_input.length==1) {
+                var raw = manual_input.get(0);
+                if (raw) {
+                    if (raw.type === 'text' || raw.type === 'file' || 
+                        raw.type == 'password' || raw.type == 'text' || 
+                        raw.type == 'textarea') { 
+                            if (!manual_input.hasClass("hasDatepicker")) {
+                                manual_input.focus();
+                                return;
+                            }
                     }
                 }
             } else {
-                /* Focus on the first element of this form (i.e. data-deform-focus-form=='auto') */
+                /* Focus on the first element of this form */
                 var input = $(form).find(':input')
                     .filter('[id ^= deformField]')
                     .filter('[type != hidden]')
                     .first();
-                if (input) {
+                
+                if(input.length==1) {
                     var raw = input.get(0);
                     if (raw) {
                         if (raw.type === 'text' || raw.type === 'file' || 
@@ -209,7 +216,6 @@ var deform  = {
                 }
             }
         }
-
     },
 
     randomString: function (length) {

--- a/deform/static/scripts/deform.js
+++ b/deform/static/scripts/deform.js
@@ -157,23 +157,59 @@ var deform  = {
      },
 
     focusFirstInput: function (el) {
+        /* If the first form on the page has its data-deform-focus-form 
+         * attribute set to 'auto', the first child input will be focused. If 
+         * the attribute is set to 'manual', the first child input with its 
+         * data-deform-manual-focus attribute set will be focused. Otherwise, no 
+         * focusing will be performed. */
         el = el || document.body;
-        var input = $(el).find(':input')
-          .filter('[id ^= deformField]')
-          .filter('[type != hidden]')
-          .first();
-        if (input) {
-            var raw = input.get(0);
-            if (raw) {
-                if (raw.type === 'text' || raw.type === 'file' || 
-                    raw.type == 'password' || raw.type == 'text' || 
-                    raw.type == 'textarea') { 
-                    if (!input.hasClass("hasDatepicker")) {
-                        input.focus();
+
+        /* Select the first form which does not have data-deform-focus-form=off */
+        var form = $(el).find('form').filter('[data-deform-focus-form != off]').first();
+
+        if(form) {
+            if($(form).attr('data-deform-focus-form') == 'manual') {
+                /* Focus on the first input with data-deform-manual-focus set */
+                var input = $(form).find(':input')
+                    .filter('[id ^= deformField]')
+                    .filter('[type != hidden]')
+                    .filter('[data-deform-manual-focus = "on"]')
+                    .first();
+                if (input) {
+                    var raw = input.get(0);
+                    if (raw) {
+                        if (raw.type === 'text' || raw.type === 'file' || 
+                            raw.type == 'password' || raw.type == 'text' || 
+                            raw.type == 'textarea') { 
+                                if (!input.hasClass("hasDatepicker")) {
+                                    input.focus();
+                                    return;
+                                }
+                        }
+                    }
+                }
+            } else {
+                /* Focus on the first element of this form (i.e. data-deform-focus-form=='auto') */
+                var input = $(form).find(':input')
+                    .filter('[id ^= deformField]')
+                    .filter('[type != hidden]')
+                    .first();
+                if (input) {
+                    var raw = input.get(0);
+                    if (raw) {
+                        if (raw.type === 'text' || raw.type === 'file' || 
+                            raw.type == 'password' || raw.type == 'text' || 
+                            raw.type == 'textarea') { 
+                                if (!input.hasClass("hasDatepicker")) {
+                                    input.focus();
+                                    return;
+                                }
+                        }
                     }
                 }
             }
         }
+
     },
 
     randomString: function (length) {

--- a/deform/static/scripts/deform.js
+++ b/deform/static/scripts/deform.js
@@ -4,10 +4,9 @@
  * to include the call at the end of the page.
  */
 
-$(document).ready(function(){
+$(document).ready(function() {
     deform.load();
 });
-
 
 var deform_loaded = false;
 
@@ -26,7 +25,6 @@ var deform  = {
       $(function() {
         if (!deform_loaded) {
             deform.processCallbacks();
-            deform.focusFirstInput();
             deform_loaded = true;
       }});
     },
@@ -155,68 +153,6 @@ var deform  = {
         oid_node.find('.deform-seq-add').not(oid_node.find('.deform-seq-container .deform-seq-add')).toggle(show_addbutton);
         $lis.find('.deform-order-button').not($lis.find('.deform-seq-container .deform-order-button')).toggle(orderable && has_multiple);
      },
-
-    focusFirstInput: function (el) {
-        /*
-         * If a form's data-deform-focus attribute is 'off', no focusing 
-         * will be done on that form.
-         *
-         * If a form's data-deform-focus attribute is 'on' AND a child 
-         * input has its data-deform-autofocus attribute set to 'on', that 
-         * input will be focused.
-         *
-         * If a form's data-deform-focus attribute is 'on' AND no child has 
-         * its data-deform-autofocus attribute set to 'on', the first input 
-         * of the form will be focused.
-         */
-        el = el || document.body;
-
-        /* Select the first form which does not have data-deform-focus=off */
-        var form = $(el).find('form').filter('[data-deform-focus = on]').first();
-
-        if(form.length==1) {
-            /* Focus on the first input with data-deform-autofocus='on' */
-            var autofocus_input = $(form).find(':input')
-                .filter('[id ^= deformField]')
-                .filter('[type != hidden]')
-                .filter('[data-deform-autofocus = "on"]')
-                .first();
-            
-            if(autofocus_input.length==1) {
-                var raw = autofocus_input.get(0);
-                if (raw) {
-                    if (raw.type === 'text' || raw.type === 'file' || 
-                        raw.type == 'password' || raw.type == 'text' || 
-                        raw.type == 'textarea') { 
-                            if (!autofocus_input.hasClass("hasDatepicker")) {
-                                autofocus_input.focus();
-                                return;
-                            }
-                    }
-                }
-            } else {
-                /* Focus on the first element of this form */
-                var input = $(form).find(':input')
-                    .filter('[id ^= deformField]')
-                    .filter('[type != hidden]')
-                    .first();
-                
-                if(input.length==1) {
-                    var raw = input.get(0);
-                    if (raw) {
-                        if (raw.type === 'text' || raw.type === 'file' || 
-                            raw.type == 'password' || raw.type == 'text' || 
-                            raw.type == 'textarea') { 
-                                if (!input.hasClass("hasDatepicker")) {
-                                    input.focus();
-                                    return;
-                                }
-                        }
-                    }
-                }
-            }
-        }
-    },
 
     randomString: function (length) {
         var chr='0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz';

--- a/deform/templates/autocomplete_input.pt
+++ b/deform/templates/autocomplete_input.pt
@@ -1,14 +1,16 @@
 <span tal:define="name name|field.name;
                   css_class css_class|field.widget.css_class;
                   oid oid|field.oid;
-                  style style|field.widget.style"
+                  style style|field.widget.style;
+                  manual_focus manual_focus|field.manual_focus"
       tal:omit-tag="">
     <input type="text"
            name="${name}"
            value="${cstruct}"
            data-provide="typeahead"
            tal:attributes="class string: form-control ${css_class or ''};
-                           style style"
+                           style style;
+                           data-deform-manual-focus manual_focus"
            id="${oid}"/>
     <script tal:condition="field.widget.values" type="text/javascript">
         deform.addCallback(

--- a/deform/templates/autocomplete_input.pt
+++ b/deform/templates/autocomplete_input.pt
@@ -2,7 +2,7 @@
                   css_class css_class|field.widget.css_class;
                   oid oid|field.oid;
                   style style|field.widget.style;
-                  manual_focus manual_focus|field.manual_focus"
+                  autofocus autofocus|field.autofocus"
       tal:omit-tag="">
     <input type="text"
            name="${name}"
@@ -10,7 +10,7 @@
            data-provide="typeahead"
            tal:attributes="class string: form-control ${css_class or ''};
                            style style;
-                           data-deform-manual-focus manual_focus"
+                           data-deform-autofocus autofocus"
            id="${oid}"/>
     <script tal:condition="field.widget.values" type="text/javascript">
         deform.addCallback(

--- a/deform/templates/autocomplete_input.pt
+++ b/deform/templates/autocomplete_input.pt
@@ -10,7 +10,7 @@
            data-provide="typeahead"
            tal:attributes="class string: form-control ${css_class or ''};
                            style style;
-                           data-deform-autofocus autofocus"
+                           autofocus autofocus"
            id="${oid}"/>
     <script tal:condition="field.widget.values" type="text/javascript">
         deform.addCallback(

--- a/deform/templates/checkbox.pt
+++ b/deform/templates/checkbox.pt
@@ -4,13 +4,15 @@
                        true_val true_val|field.widget.true_val;
                        css_class css_class|field.widget.css_class;
                        style style|field.widget.style;
-                       oid oid|field.oid"
+                       oid oid|field.oid;
+                       manual_focus manual_focus|field.manual_focus"
            type="checkbox"
            name="${name}" value="${true_val}"
            id="${oid}"
            tal:attributes="checked cstruct == true_val;
                            class css_class;
-                           style style;" />
+                           style style;
+                           data-deform-manual-focus manual_focus" />
 
     <span tal:condition="hasattr(field, 'schema') and hasattr(field.schema, 'label')"
           tal:replace="field.schema.label" class="checkbox-label" >

--- a/deform/templates/checkbox.pt
+++ b/deform/templates/checkbox.pt
@@ -5,7 +5,7 @@
                        css_class css_class|field.widget.css_class;
                        style style|field.widget.style;
                        oid oid|field.oid;
-                       manual_focus manual_focus|field.manual_focus"
+                       manual_focus manual_focus|field.manual_focus|None"
            type="checkbox"
            name="${name}" value="${true_val}"
            id="${oid}"

--- a/deform/templates/checkbox.pt
+++ b/deform/templates/checkbox.pt
@@ -5,14 +5,14 @@
                        css_class css_class|field.widget.css_class;
                        style style|field.widget.style;
                        oid oid|field.oid;
-                       manual_focus manual_focus|field.manual_focus|None"
+                       autofocus autofocus|field.autofocus|None"
            type="checkbox"
            name="${name}" value="${true_val}"
            id="${oid}"
            tal:attributes="checked cstruct == true_val;
                            class css_class;
                            style style;
-                           data-deform-manual-focus manual_focus" />
+                           data-deform-autofocus autofocus" />
 
     <span tal:condition="hasattr(field, 'schema') and hasattr(field.schema, 'label')"
           tal:replace="field.schema.label" class="checkbox-label" >

--- a/deform/templates/checkbox.pt
+++ b/deform/templates/checkbox.pt
@@ -12,7 +12,7 @@
            tal:attributes="checked cstruct == true_val;
                            class css_class;
                            style style;
-                           data-deform-autofocus autofocus" />
+                           autofocus autofocus" />
 
     <span tal:condition="hasattr(field, 'schema') and hasattr(field.schema, 'label')"
           tal:replace="field.schema.label" class="checkbox-label" >

--- a/deform/templates/checkbox_choice.pt
+++ b/deform/templates/checkbox_choice.pt
@@ -14,7 +14,7 @@
       <input tal:attributes="checked value in cstruct;
                              class css_class;
                              style style;
-                             data-deform-autofocus autofocus"
+                             autofocus autofocus"
              type="checkbox"
              name="checkbox"
              value="${value}"

--- a/deform/templates/checkbox_choice.pt
+++ b/deform/templates/checkbox_choice.pt
@@ -1,7 +1,8 @@
 <div tal:define="css_class css_class|field.widget.css_class;
                  style style|field.widget.style;
                  oid oid|field.oid;
-                 inline getattr(field.widget, 'inline', False)"
+                 inline getattr(field.widget, 'inline', False);
+                 manual_focus manual_focus|field.manual_focus"
      tal:omit-tag="not inline">
   ${field.start_sequence()}
   <div tal:repeat="choice values | field.widget.values"
@@ -12,7 +13,8 @@
            tal:attributes="class inline and 'checkbox-inline'">
       <input tal:attributes="checked value in cstruct;
                              class css_class;
-                             style style"
+                             style style;
+                             data-deform-manual-focus manual_focus"
              type="checkbox"
              name="checkbox"
              value="${value}"

--- a/deform/templates/checkbox_choice.pt
+++ b/deform/templates/checkbox_choice.pt
@@ -2,7 +2,7 @@
                  style style|field.widget.style;
                  oid oid|field.oid;
                  inline getattr(field.widget, 'inline', False);
-                 manual_focus manual_focus|field.manual_focus"
+                 autofocus autofocus|field.autofocus"
      tal:omit-tag="not inline">
   ${field.start_sequence()}
   <div tal:repeat="choice values | field.widget.values"
@@ -14,7 +14,7 @@
       <input tal:attributes="checked value in cstruct;
                              class css_class;
                              style style;
-                             data-deform-manual-focus manual_focus"
+                             data-deform-autofocus autofocus"
              type="checkbox"
              name="checkbox"
              value="${value}"

--- a/deform/templates/checked_input.pt
+++ b/deform/templates/checked_input.pt
@@ -3,7 +3,8 @@
                  css_class css_class|field.widget.css_class;
                  style style|field.widget.style;
                  mask mask|field.widget.mask;
-                 mask_placeholder mask_placeholder|field.widget.mask_placeholder;"
+                 mask_placeholder mask_placeholder|field.widget.mask_placeholder;
+                 manual_focus manual_focus|field.manual_focus"
      i18n:domain="deform"
      tal:omit-tag="">
   ${field.start_mapping()}
@@ -11,7 +12,8 @@
     <input type="text" name="${name}" value="${cstruct}"
            tal:attributes="style style;
                            class string: form-control ${css_class or ''};
-                           placeholder subject;"
+                           placeholder subject;
+                           data-deform-manual-focus manual_focus"
            id="${oid}"/>
   </div>
   <div>

--- a/deform/templates/checked_input.pt
+++ b/deform/templates/checked_input.pt
@@ -13,7 +13,7 @@
            tal:attributes="style style;
                            class string: form-control ${css_class or ''};
                            placeholder subject;
-                           data-deform-autofocus autofocus"
+                           autofocus autofocus"
            id="${oid}"/>
   </div>
   <div>

--- a/deform/templates/checked_input.pt
+++ b/deform/templates/checked_input.pt
@@ -4,7 +4,7 @@
                  style style|field.widget.style;
                  mask mask|field.widget.mask;
                  mask_placeholder mask_placeholder|field.widget.mask_placeholder;
-                 manual_focus manual_focus|field.manual_focus"
+                 autofocus autofocus|field.autofocus"
      i18n:domain="deform"
      tal:omit-tag="">
   ${field.start_mapping()}
@@ -13,7 +13,7 @@
            tal:attributes="style style;
                            class string: form-control ${css_class or ''};
                            placeholder subject;
-                           data-deform-manual-focus manual_focus"
+                           data-deform-autofocus autofocus"
            id="${oid}"/>
   </div>
   <div>

--- a/deform/templates/checked_password.pt
+++ b/deform/templates/checked_password.pt
@@ -3,7 +3,7 @@
                   name name|field.name;
                   css_class css_class|field.widget.css_class;
                   style style|field.widget.style;
-                  manual_focus manual_focus|field.manual_focus">
+                  autofocus autofocus|field.autofocus">
 ${field.start_mapping()}
 <div>
   <input type="password"
@@ -11,7 +11,7 @@ ${field.start_mapping()}
          value="${field.widget.redisplay and cstruct or ''}"
          tal:attributes="class string: form-control ${css_class or ''};
                          style style;
-                         data-deform-manual-focus manual_focus"
+                         data-deform-autofocus autofocus"
          id="${oid}"
          i18n:attributes="placeholder"
          placeholder="Password"/>

--- a/deform/templates/checked_password.pt
+++ b/deform/templates/checked_password.pt
@@ -11,7 +11,7 @@ ${field.start_mapping()}
          value="${field.widget.redisplay and cstruct or ''}"
          tal:attributes="class string: form-control ${css_class or ''};
                          style style;
-                         data-deform-autofocus autofocus"
+                         autofocus autofocus"
          id="${oid}"
          i18n:attributes="placeholder"
          placeholder="Password"/>

--- a/deform/templates/checked_password.pt
+++ b/deform/templates/checked_password.pt
@@ -2,14 +2,16 @@
       tal:define="oid oid|field.oid;
                   name name|field.name;
                   css_class css_class|field.widget.css_class;
-                  style style|field.widget.style">
+                  style style|field.widget.style;
+                  manual_focus manual_focus|field.manual_focus">
 ${field.start_mapping()}
 <div>
   <input type="password"
          name="${name}"
          value="${field.widget.redisplay and cstruct or ''}"
          tal:attributes="class string: form-control ${css_class or ''};
-                         style style;"
+                         style style;
+                         data-deform-manual-focus manual_focus"
          id="${oid}"
          i18n:attributes="placeholder"
          placeholder="Password"/>

--- a/deform/templates/dateinput.pt
+++ b/deform/templates/dateinput.pt
@@ -1,7 +1,8 @@
 <div tal:define="css_class css_class|field.widget.css_class;
                  oid oid|field.oid;
                  style style|field.widget.style;
-                 type_name type_name|field.widget.type_name;"
+                 type_name type_name|field.widget.type_name;
+                 manual_focus manual_focus|field.manual_focus"
       tal:omit-tag="">
   ${field.start_mapping()}
   <input type="${type_name}"
@@ -9,7 +10,8 @@
          value="${cstruct}"
          
          tal:attributes="class string: ${css_class or ''} form-control hasDatepicker;
-                         style style"
+                         style style;
+                         data-deform-manual-focus manual_focus"
          id="${oid}"/>
   ${field.end_mapping()}
   <script type="text/javascript">

--- a/deform/templates/dateinput.pt
+++ b/deform/templates/dateinput.pt
@@ -11,7 +11,7 @@
          
          tal:attributes="class string: ${css_class or ''} form-control hasDatepicker;
                          style style;
-                         data-deform-autofocus autofocus"
+                         autofocus autofocus"
          id="${oid}"/>
   ${field.end_mapping()}
   <script type="text/javascript">

--- a/deform/templates/dateinput.pt
+++ b/deform/templates/dateinput.pt
@@ -2,7 +2,7 @@
                  oid oid|field.oid;
                  style style|field.widget.style;
                  type_name type_name|field.widget.type_name;
-                 manual_focus manual_focus|field.manual_focus"
+                 autofocus autofocus|field.autofocus"
       tal:omit-tag="">
   ${field.start_mapping()}
   <input type="${type_name}"
@@ -11,7 +11,7 @@
          
          tal:attributes="class string: ${css_class or ''} form-control hasDatepicker;
                          style style;
-                         data-deform-manual-focus manual_focus"
+                         data-deform-autofocus autofocus"
          id="${oid}"/>
   ${field.end_mapping()}
   <script type="text/javascript">

--- a/deform/templates/dateparts.pt
+++ b/deform/templates/dateparts.pt
@@ -3,14 +3,16 @@
       tal:define="oid oid|field.oid;
                   name name|field.name;
                   css_class css_class|field.widget.css_class;
-                  style style|field.widget.style;">
+                  style style|field.widget.style;
+                  manual_focus manual_focus|field.manual_focus">
   ${field.start_mapping()}
   <div class="row">
     <div class="input-group col-xs-4">
       <span class="input-group-addon" i18n:translate="">Year</span>
       <input type="text" name="year" value="${year}"
              class="span2 form-control ${css_class or ''}"
-             tal:attributes="style style"
+             tal:attributes="style style;
+                             data-deform-manual-focus manual_focus"
              maxlength="4"
              id="${oid}"/>
     </div>

--- a/deform/templates/dateparts.pt
+++ b/deform/templates/dateparts.pt
@@ -4,7 +4,7 @@
                   name name|field.name;
                   css_class css_class|field.widget.css_class;
                   style style|field.widget.style;
-                  manual_focus manual_focus|field.manual_focus">
+                  autofocus autofocus|field.autofocus">
   ${field.start_mapping()}
   <div class="row">
     <div class="input-group col-xs-4">
@@ -12,7 +12,7 @@
       <input type="text" name="year" value="${year}"
              class="span2 form-control ${css_class or ''}"
              tal:attributes="style style;
-                             data-deform-manual-focus manual_focus"
+                             data-deform-autofocus autofocus"
              maxlength="4"
              id="${oid}"/>
     </div>

--- a/deform/templates/dateparts.pt
+++ b/deform/templates/dateparts.pt
@@ -12,7 +12,7 @@
       <input type="text" name="year" value="${year}"
              class="span2 form-control ${css_class or ''}"
              tal:attributes="style style;
-                             data-deform-autofocus autofocus"
+                             autofocus autofocus"
              maxlength="4"
              id="${oid}"/>
     </div>

--- a/deform/templates/datetimeinput.pt
+++ b/deform/templates/datetimeinput.pt
@@ -11,7 +11,7 @@
       <input type="text" name="date" value="${date}"
              class="span2 form-control ${css_class or ''} hasDatepicker"
              tal:attributes="style style;
-                             data-deform-autofocus autofocus"
+                             autofocus autofocus"
              id="${oid}-date"/>
     </div>
     <div class="input-group col-xs-6">

--- a/deform/templates/datetimeinput.pt
+++ b/deform/templates/datetimeinput.pt
@@ -3,7 +3,7 @@
       tal:define="oid oid|field.oid;
                   css_class css_class|field.widget.css_class;
                   style style|field.widget.style;
-                  manual_focus manual_focus|field.manual_focus">
+                  autofocus autofocus|field.autofocus">
   ${field.start_mapping()}
   <div class="row">
     <div class="input-group col-xs-6">
@@ -11,7 +11,7 @@
       <input type="text" name="date" value="${date}"
              class="span2 form-control ${css_class or ''} hasDatepicker"
              tal:attributes="style style;
-                             data-deform-manual-focus manual_focus"
+                             data-deform-autofocus autofocus"
              id="${oid}-date"/>
     </div>
     <div class="input-group col-xs-6">

--- a/deform/templates/datetimeinput.pt
+++ b/deform/templates/datetimeinput.pt
@@ -2,14 +2,16 @@
       tal:omit-tag=""
       tal:define="oid oid|field.oid;
                   css_class css_class|field.widget.css_class;
-                  style style|field.widget.style;">
+                  style style|field.widget.style;
+                  manual_focus manual_focus|field.manual_focus">
   ${field.start_mapping()}
   <div class="row">
     <div class="input-group col-xs-6">
       <span class="input-group-addon" i18n:translate="">Date</span>
       <input type="text" name="date" value="${date}"
              class="span2 form-control ${css_class or ''} hasDatepicker"
-             tal:attributes="style style"
+             tal:attributes="style style;
+                             data-deform-manual-focus manual_focus"
              id="${oid}-date"/>
     </div>
     <div class="input-group col-xs-6">

--- a/deform/templates/file_upload.pt
+++ b/deform/templates/file_upload.pt
@@ -18,7 +18,7 @@
   <input type="file" name="upload" 
          tal:attributes="class css_class;
                          style style;
-                         data-deform-autofocus autofocus"
+                         autofocus autofocus"
          id="${oid}"/>
 
   ${field.end_mapping()}

--- a/deform/templates/file_upload.pt
+++ b/deform/templates/file_upload.pt
@@ -1,7 +1,8 @@
 <div class="deform-file-upload"
      tal:define="oid oid|field.oid;
                  css_class css_class|field.widget.css_class;
-                 style style|field.widget.style">
+                 style style|field.widget.style;
+                 manual_focus manual_focus|field.manual_focus">
 
   ${field.start_mapping()}
 
@@ -16,7 +17,8 @@
 
   <input type="file" name="upload" 
          tal:attributes="class css_class;
-                         style style;"
+                         style style;
+                         data-deform-manual-focus manual_focus"
          id="${oid}"/>
 
   ${field.end_mapping()}

--- a/deform/templates/file_upload.pt
+++ b/deform/templates/file_upload.pt
@@ -2,7 +2,7 @@
      tal:define="oid oid|field.oid;
                  css_class css_class|field.widget.css_class;
                  style style|field.widget.style;
-                 manual_focus manual_focus|field.manual_focus">
+                 autofocus autofocus|field.autofocus">
 
   ${field.start_mapping()}
 
@@ -18,7 +18,7 @@
   <input type="file" name="upload" 
          tal:attributes="class css_class;
                          style style;
-                         data-deform-manual-focus manual_focus"
+                         data-deform-autofocus autofocus"
          id="${oid}"/>
 
   ${field.end_mapping()}

--- a/deform/templates/form.pt
+++ b/deform/templates/form.pt
@@ -3,6 +3,7 @@
               css_class css_class|string:${field.widget.css_class or field.css_class or ''};
               item_template item_template|field.widget.item_template;
               autocomplete autocomplete|field.autocomplete;
+              focus_form focus_form|field.focus_form;
               title title|field.title;
               errormsg errormsg|field.errormsg;
               description description|field.description;
@@ -15,7 +16,8 @@
   tal:attributes="autocomplete autocomplete;
                   style style;
                   class css_class;
-                  action action;"
+                  action action;
+                  data-deform-focus-form focus_form;"
   id="${formid}"
   method="${method}"
   enctype="multipart/form-data"

--- a/deform/templates/form.pt
+++ b/deform/templates/form.pt
@@ -3,7 +3,6 @@
               css_class css_class|string:${field.widget.css_class or field.css_class or ''};
               item_template item_template|field.widget.item_template;
               autocomplete autocomplete|field.autocomplete;
-              focus focus|field.focus;
               title title|field.title;
               errormsg errormsg|field.errormsg;
               description description|field.description;
@@ -16,8 +15,7 @@
   tal:attributes="autocomplete autocomplete;
                   style style;
                   class css_class;
-                  action action;
-                  data-deform-focus focus;"
+                  action action;"
   id="${formid}"
   method="${method}"
   enctype="multipart/form-data"

--- a/deform/templates/form.pt
+++ b/deform/templates/form.pt
@@ -3,7 +3,7 @@
               css_class css_class|string:${field.widget.css_class or field.css_class or ''};
               item_template item_template|field.widget.item_template;
               autocomplete autocomplete|field.autocomplete;
-              focus_form focus_form|field.focus_form;
+              focus focus|field.focus;
               title title|field.title;
               errormsg errormsg|field.errormsg;
               description description|field.description;
@@ -17,7 +17,7 @@
                   style style;
                   class css_class;
                   action action;
-                  data-deform-focus-form focus_form;"
+                  data-deform-focus focus;"
   id="${formid}"
   method="${method}"
   enctype="multipart/form-data"

--- a/deform/templates/moneyinput.pt
+++ b/deform/templates/moneyinput.pt
@@ -9,7 +9,7 @@
     <input type="text" name="${name}" value="${cstruct}" 
            tal:attributes="style style;
                            class string: form-control ${css_class or ''};
-                           data-deform-autofocus autofocus"
+                           autofocus autofocus"
            id="${oid}"/>
     <script type="text/javascript">
       deform.addCallback(

--- a/deform/templates/moneyinput.pt
+++ b/deform/templates/moneyinput.pt
@@ -4,12 +4,12 @@
                   style style|field.widget.style;
                   css_class css_class|field.widget.css_class;
                   style style|field.widget.style|False;
-                  manual_focus manual_focus|field.manual_focus"
+                  autofocus autofocus|field.autofocus"
       tal:omit-tag="">
     <input type="text" name="${name}" value="${cstruct}" 
            tal:attributes="style style;
                            class string: form-control ${css_class or ''};
-                           data-deform-manual-focus manual_focus"
+                           data-deform-autofocus autofocus"
            id="${oid}"/>
     <script type="text/javascript">
       deform.addCallback(

--- a/deform/templates/moneyinput.pt
+++ b/deform/templates/moneyinput.pt
@@ -3,11 +3,13 @@
                   mask_options mask_options|'{}';
                   style style|field.widget.style;
                   css_class css_class|field.widget.css_class;
-                  style style|field.widget.style|False"
+                  style style|field.widget.style|False;
+                  manual_focus manual_focus|field.manual_focus"
       tal:omit-tag="">
     <input type="text" name="${name}" value="${cstruct}" 
            tal:attributes="style style;
-                           class string: form-control ${css_class or ''}"
+                           class string: form-control ${css_class or ''};
+                           data-deform-manual-focus manual_focus"
            id="${oid}"/>
     <script type="text/javascript">
       deform.addCallback(

--- a/deform/templates/password.pt
+++ b/deform/templates/password.pt
@@ -5,6 +5,6 @@
     value="${field.widget.redisplay and cstruct or ''}" 
     tal:attributes="style style|field.widget.style;
                     class string: form-control ${css_class|field.widget.css_class or ''};
-                    data-deform-autofocus autofocus"
+                    autofocus autofocus"
     id="${oid|field.oid}"/>
 

--- a/deform/templates/password.pt
+++ b/deform/templates/password.pt
@@ -1,10 +1,10 @@
 <input 
-    tal:define="manual_focus manual_focus|field.manual_focus"
+    tal:define="autofocus autofocus|field.autofocus"
     type="password" 
     name="${name|field.name}" 
     value="${field.widget.redisplay and cstruct or ''}" 
     tal:attributes="style style|field.widget.style;
                     class string: form-control ${css_class|field.widget.css_class or ''};
-                    data-deform-manual-focus manual_focus"
+                    data-deform-autofocus autofocus"
     id="${oid|field.oid}"/>
 

--- a/deform/templates/password.pt
+++ b/deform/templates/password.pt
@@ -1,8 +1,10 @@
 <input 
+    tal:define="manual_focus manual_focus|field.manual_focus"
     type="password" 
     name="${name|field.name}" 
     value="${field.widget.redisplay and cstruct or ''}" 
     tal:attributes="style style|field.widget.style;
-                    class string: form-control ${css_class|field.widget.css_class or ''};"
+                    class string: form-control ${css_class|field.widget.css_class or ''};
+                    data-deform-manual-focus manual_focus"
     id="${oid|field.oid}"/>
 

--- a/deform/templates/radio_choice.pt
+++ b/deform/templates/radio_choice.pt
@@ -1,7 +1,8 @@
 <div tal:define="oid oid|field.oid;
                  css_class css_class|field.widget.css_class;
                  style style|field.widget.style;
-                 inline getattr(field.widget, 'inline', False);"
+                 inline getattr(field.widget, 'inline', False);
+                 manual_focus manual_focus|field.manual_focus"
      tal:omit-tag="not inline">
   ${field.start_rename()}
   <div tal:repeat="choice values | field.widget.values"
@@ -12,7 +13,8 @@
            tal:attributes="class inline and 'radio-inline'">
       <input tal:attributes="checked value == cstruct;
                              class css_class;
-                             style style;"
+                             style style;
+                             data-deform-manual-focus manual_focus"
              type="radio"
              name="${oid}"
              value="${value}"

--- a/deform/templates/radio_choice.pt
+++ b/deform/templates/radio_choice.pt
@@ -14,7 +14,7 @@
       <input tal:attributes="checked value == cstruct;
                              class css_class;
                              style style;
-                             data-deform-autofocus autofocus"
+                             autofocus autofocus"
              type="radio"
              name="${oid}"
              value="${value}"

--- a/deform/templates/radio_choice.pt
+++ b/deform/templates/radio_choice.pt
@@ -2,7 +2,7 @@
                  css_class css_class|field.widget.css_class;
                  style style|field.widget.style;
                  inline getattr(field.widget, 'inline', False);
-                 manual_focus manual_focus|field.manual_focus"
+                 autofocus autofocus|field.autofocus"
      tal:omit-tag="not inline">
   ${field.start_rename()}
   <div tal:repeat="choice values | field.widget.values"
@@ -14,7 +14,7 @@
       <input tal:attributes="checked value == cstruct;
                              class css_class;
                              style style;
-                             data-deform-manual-focus manual_focus"
+                             data-deform-autofocus autofocus"
              type="radio"
              name="${oid}"
              value="${value}"

--- a/deform/templates/richtext.pt
+++ b/deform/templates/richtext.pt
@@ -1,7 +1,9 @@
 <div tal:define="delayed_load delayed_load|field.widget.delayed_load;
                  tinymce_options tinymce_options|field.widget.tinymce_options;
                  oid oid|field.oid;
-                 name name|field.name;"
+                 name name|field.name;
+                 manual_focus manual_focus|field.manual_focus"
+
     xmlns:i18n="http://xml.zope.org/namespaces/i18n" 
     i18n:domain="deform"
     tal:omit-tag="">
@@ -14,7 +16,8 @@
       }
     </style>  
   <textarea id="${oid}" name="${name}" 
-            class='tinymce form-control' tal:content="structure cstruct" />
+            class='tinymce form-control' tal:content="structure cstruct" 
+            tal:attributes="data-deform-manual-focus manual_focus"/>
   <span id="${oid}-preload" class="tinymce-preload" 
         tal:content="structure cstruct" />
   <script type="text/javascript">

--- a/deform/templates/richtext.pt
+++ b/deform/templates/richtext.pt
@@ -17,7 +17,7 @@
     </style>  
   <textarea id="${oid}" name="${name}" 
             class='tinymce form-control' tal:content="structure cstruct" 
-            tal:attributes="data-deform-autofocus autofocus"/>
+            tal:attributes="autofocus autofocus"/>
   <span id="${oid}-preload" class="tinymce-preload" 
         tal:content="structure cstruct" />
   <script type="text/javascript">

--- a/deform/templates/richtext.pt
+++ b/deform/templates/richtext.pt
@@ -2,7 +2,7 @@
                  tinymce_options tinymce_options|field.widget.tinymce_options;
                  oid oid|field.oid;
                  name name|field.name;
-                 manual_focus manual_focus|field.manual_focus"
+                 autofocus autofocus|field.autofocus"
 
     xmlns:i18n="http://xml.zope.org/namespaces/i18n" 
     i18n:domain="deform"
@@ -17,7 +17,7 @@
     </style>  
   <textarea id="${oid}" name="${name}" 
             class='tinymce form-control' tal:content="structure cstruct" 
-            tal:attributes="data-deform-manual-focus manual_focus"/>
+            tal:attributes="data-deform-autofocus autofocus"/>
   <span id="${oid}-preload" class="tinymce-preload" 
         tal:content="structure cstruct" />
   <script type="text/javascript">

--- a/deform/templates/select.pt
+++ b/deform/templates/select.pt
@@ -5,7 +5,8 @@
      size size|field.widget.size;
      css_class css_class|field.widget.css_class;
      optgroup_class optgroup_class|field.widget.optgroup_class;
-     multiple multiple|field.widget.multiple;"
+     multiple multiple|field.widget.multiple;
+     manual_focus manual_focus|field.manual_focus"
      tal:omit-tag="">
   <input type="hidden" name="__start__" value="${name}:sequence"
          tal:condition="multiple" />
@@ -15,7 +16,8 @@
           class string: form-control ${css_class or ''};
           multiple multiple;
           size size;
-          style style;">
+          style style;
+          data-deform-manual-focus manual_focus">
     <tal:loop tal:repeat="item values">
       <optgroup tal:condition="isinstance(item, optgroup_class)"
                 tal:attributes="label item.label">

--- a/deform/templates/select.pt
+++ b/deform/templates/select.pt
@@ -17,7 +17,7 @@
           multiple multiple;
           size size;
           style style;
-          data-deform-autofocus autofocus">
+          autofocus autofocus">
     <tal:loop tal:repeat="item values">
       <optgroup tal:condition="isinstance(item, optgroup_class)"
                 tal:attributes="label item.label">

--- a/deform/templates/select.pt
+++ b/deform/templates/select.pt
@@ -6,7 +6,7 @@
      css_class css_class|field.widget.css_class;
      optgroup_class optgroup_class|field.widget.optgroup_class;
      multiple multiple|field.widget.multiple;
-     manual_focus manual_focus|field.manual_focus"
+     autofocus autofocus|field.autofocus"
      tal:omit-tag="">
   <input type="hidden" name="__start__" value="${name}:sequence"
          tal:condition="multiple" />
@@ -17,7 +17,7 @@
           multiple multiple;
           size size;
           style style;
-          data-deform-manual-focus manual_focus">
+          data-deform-autofocus autofocus">
     <tal:loop tal:repeat="item values">
       <optgroup tal:condition="isinstance(item, optgroup_class)"
                 tal:attributes="label item.label">

--- a/deform/templates/select2.pt
+++ b/deform/templates/select2.pt
@@ -47,7 +47,7 @@
           data-placeholder field.widget.placeholder|None;
           multiple multiple;
           style style;
-          data-deform-autofocus autofocus">
+          autofocus autofocus">
     <tal:loop tal:repeat="item values">
       <optgroup tal:condition="isinstance(item, optgroup_class)"
                 tal:attributes="label item.label">

--- a/deform/templates/select2.pt
+++ b/deform/templates/select2.pt
@@ -5,7 +5,7 @@
      css_class css_class|field.widget.css_class;
      optgroup_class optgroup_class|field.widget.optgroup_class;
      multiple multiple|field.widget.multiple;
-     manual_focus manual_focus|field.manual_focus"
+     autofocus autofocus|field.autofocus"
      tal:omit-tag="">
 
    <style>
@@ -47,7 +47,7 @@
           data-placeholder field.widget.placeholder|None;
           multiple multiple;
           style style;
-          data-deform-manual-focus manual_focus">
+          data-deform-autofocus autofocus">
     <tal:loop tal:repeat="item values">
       <optgroup tal:condition="isinstance(item, optgroup_class)"
                 tal:attributes="label item.label">

--- a/deform/templates/select2.pt
+++ b/deform/templates/select2.pt
@@ -4,7 +4,8 @@
      oid oid|field.oid;
      css_class css_class|field.widget.css_class;
      optgroup_class optgroup_class|field.widget.optgroup_class;
-     multiple multiple|field.widget.multiple;"
+     multiple multiple|field.widget.multiple;
+     manual_focus manual_focus|field.manual_focus"
      tal:omit-tag="">
 
    <style>
@@ -45,7 +46,8 @@
           class string: form-control ${css_class or ''};
           data-placeholder field.widget.placeholder|None;
           multiple multiple;
-          style style;">
+          style style;
+          data-deform-manual-focus manual_focus">
     <tal:loop tal:repeat="item values">
       <optgroup tal:condition="isinstance(item, optgroup_class)"
                 tal:attributes="label item.label">

--- a/deform/templates/textarea.pt
+++ b/deform/templates/textarea.pt
@@ -9,6 +9,6 @@
                           cols cols;
                           class string: form-control ${css_class or ''};
                           style style;
-                          data-deform-autofocus autofocus"
+                          autofocus autofocus"
           id="${oid}"
           name="${name}">${cstruct}</textarea>

--- a/deform/templates/textarea.pt
+++ b/deform/templates/textarea.pt
@@ -4,11 +4,11 @@
                       oid oid|field.oid;
                       name name|field.name;
                       style style|field.widget.style;
-                      manual_focus manual_focus|field.manual_focus"
+                      autofocus autofocus|field.autofocus"
           tal:attributes="rows rows;
                           cols cols;
                           class string: form-control ${css_class or ''};
                           style style;
-                          data-deform-manual-focus manual_focus"
+                          data-deform-autofocus autofocus"
           id="${oid}"
           name="${name}">${cstruct}</textarea>

--- a/deform/templates/textarea.pt
+++ b/deform/templates/textarea.pt
@@ -3,10 +3,12 @@
                       css_class css_class|field.widget.css_class;
                       oid oid|field.oid;
                       name name|field.name;
-                      style style|field.widget.style"
+                      style style|field.widget.style;
+                      manual_focus manual_focus|field.manual_focus"
           tal:attributes="rows rows;
                           cols cols;
                           class string: form-control ${css_class or ''};
-                          style style"
+                          style style;
+                          data-deform-manual-focus manual_focus"
           id="${oid}"
           name="${name}">${cstruct}</textarea>

--- a/deform/templates/textinput.pt
+++ b/deform/templates/textinput.pt
@@ -4,12 +4,12 @@
                   mask mask|field.widget.mask;
                   mask_placeholder mask_placeholder|field.widget.mask_placeholder;
                   style style|field.widget.style;
-                  manual_focus manual_focus|field.manual_focus"
+                  autofocus autofocus|field.autofocus"
       tal:omit-tag="">
     <input type="text" name="${name}" value="${cstruct}" 
            tal:attributes="class string: form-control ${css_class or ''};
                            style style;
-                           data-deform-manual-focus manual_focus"
+                           data-deform-autofocus autofocus"
            id="${oid}"/>
     <script tal:condition="mask" type="text/javascript">
       deform.addCallback(

--- a/deform/templates/textinput.pt
+++ b/deform/templates/textinput.pt
@@ -4,11 +4,12 @@
                   mask mask|field.widget.mask;
                   mask_placeholder mask_placeholder|field.widget.mask_placeholder;
                   style style|field.widget.style;
-"
+                  manual_focus manual_focus|field.manual_focus"
       tal:omit-tag="">
     <input type="text" name="${name}" value="${cstruct}" 
            tal:attributes="class string: form-control ${css_class or ''};
-                           style style"
+                           style style;
+                           data-deform-manual-focus manual_focus"
            id="${oid}"/>
     <script tal:condition="mask" type="text/javascript">
       deform.addCallback(

--- a/deform/templates/textinput.pt
+++ b/deform/templates/textinput.pt
@@ -9,7 +9,7 @@
     <input type="text" name="${name}" value="${cstruct}" 
            tal:attributes="class string: form-control ${css_class or ''};
                            style style;
-                           data-deform-autofocus autofocus"
+                           autofocus autofocus"
            id="${oid}"/>
     <script tal:condition="mask" type="text/javascript">
       deform.addCallback(

--- a/deform/templates/timeinput.pt
+++ b/deform/templates/timeinput.pt
@@ -2,7 +2,8 @@
                   css_class css_class|field.widget.css_class;
                   oid oid|field.oid;
                   style style|field.widget.style|None;
-                  type_name type_name|field.widget.type_name;"
+                  type_name type_name|field.widget.type_name;
+                  manual_focus manual_focus|field.manual_focus"
       tal:omit-tag="">
   ${field.start_mapping()}
   <input type="${type_name}"
@@ -10,7 +11,8 @@
          value="${cstruct}"
          tal:attributes="size size;
                          class string: ${css_class or ''} form-control hasDatepicker;
-                         style style"
+                         style style;
+                         data-deform-manual-focus manual_focus"
          id="${oid}"/>
   ${field.end_mapping()}
   <script type="text/javascript">

--- a/deform/templates/timeinput.pt
+++ b/deform/templates/timeinput.pt
@@ -12,7 +12,7 @@
          tal:attributes="size size;
                          class string: ${css_class or ''} form-control hasDatepicker;
                          style style;
-                         data-deform-autofocus autofocus"
+                         autofocus autofocus"
          id="${oid}"/>
   ${field.end_mapping()}
   <script type="text/javascript">

--- a/deform/templates/timeinput.pt
+++ b/deform/templates/timeinput.pt
@@ -3,7 +3,7 @@
                   oid oid|field.oid;
                   style style|field.widget.style|None;
                   type_name type_name|field.widget.type_name;
-                  manual_focus manual_focus|field.manual_focus"
+                  autofocus autofocus|field.autofocus"
       tal:omit-tag="">
   ${field.start_mapping()}
   <input type="${type_name}"
@@ -12,7 +12,7 @@
          tal:attributes="size size;
                          class string: ${css_class or ''} form-control hasDatepicker;
                          style style;
-                         data-deform-manual-focus manual_focus"
+                         data-deform-autofocus autofocus"
          id="${oid}"/>
   ${field.end_mapping()}
   <script type="text/javascript">

--- a/deform/tests/test_field.py
+++ b/deform/tests/test_field.py
@@ -33,6 +33,7 @@ class TestField(unittest.TestCase):
         self.assertEqual(field.children, [])
         self.assertEqual(field.typ, schema.typ)
         self.assertEqual(field.parent, None)
+        self.assertEqual(field.manual_focus, None)
 
     def test_ctor_custom_oid(self):
         schema = DummySchema()

--- a/deform/tests/test_field.py
+++ b/deform/tests/test_field.py
@@ -682,6 +682,20 @@ class TestField(unittest.TestCase):
             '<input type="hidden" name="__end__" value="name:rename"/>'
             )
 
+    def test_found_first(self):
+        from deform.field import Field
+        schema = DummySchema()
+        root = self._makeOne(schema, renderer='abc')
+        child1 = Field(schema,name='child1', parent=root)
+        root.children = [child1]
+        
+        self.assertNotEqual(root.children[0].have_first_input, True)
+        self.assertNotEqual(root.have_first_input, True)
+        
+        root.children[0].found_first()
+        self.assertEqual(root.children[0].have_first_input, True)
+        self.assertEqual(root.have_first_input, True)
+
 class DummyField(object):
     oid = 'oid'
     requirements = ( ('abc', '123'), ('def', '456'))

--- a/deform/tests/test_field.py
+++ b/deform/tests/test_field.py
@@ -33,7 +33,7 @@ class TestField(unittest.TestCase):
         self.assertEqual(field.children, [])
         self.assertEqual(field.typ, schema.typ)
         self.assertEqual(field.parent, None)
-        self.assertEqual(field.manual_focus, None)
+        self.assertEqual(field.autofocus, None)
 
     def test_ctor_custom_oid(self):
         schema = DummySchema()

--- a/deform/tests/test_form.py
+++ b/deform/tests/test_form.py
@@ -74,29 +74,23 @@ class TestForm(unittest.TestCase):
         form = self._makeOne(schema, autocomplete=False)
         self.assertEqual(form.autocomplete, 'off')
 
-    def test_ctor_focus_form_default(self):
+    def test_ctor_focus_default(self):
         schema = DummySchema()
         schema.children = [DummySchema()]
         form = self._makeOne(schema)
-        self.assertEqual(form.focus_form, 'auto')
+        self.assertEqual(form.focus, 'on')
 
-    def test_ctor_focus_form_default(self):
+    def test_ctor_focus_on(self):
         schema = DummySchema()
         schema.children = [DummySchema()]
-        form = self._makeOne(schema)
-        self.assertEqual(form.focus_form, 'on')
+        form = self._makeOne(schema, focus='on')
+        self.assertEqual(form.focus, 'on')
     
-    def test_ctor_focus_form_on(self):
+    def test_ctor_focus_off(self):
         schema = DummySchema()
         schema.children = [DummySchema()]
-        form = self._makeOne(schema, focus_form='on')
-        self.assertEqual(form.focus_form, 'on')
-    
-    def test_ctor_focus_form_off(self):
-        schema = DummySchema()
-        schema.children = [DummySchema()]
-        form = self._makeOne(schema, focus_form='off')
-        self.assertEqual(form.focus_form, 'off')
+        form = self._makeOne(schema, focus='off')
+        self.assertEqual(form.focus, 'off')
 
 class TestIssues(unittest.TestCase):
 

--- a/deform/tests/test_form.py
+++ b/deform/tests/test_form.py
@@ -80,18 +80,18 @@ class TestForm(unittest.TestCase):
         form = self._makeOne(schema)
         self.assertEqual(form.focus_form, 'auto')
 
-    def test_ctor_focus_form_auto(self):
+    def test_ctor_focus_form_default(self):
         schema = DummySchema()
         schema.children = [DummySchema()]
-        form = self._makeOne(schema, focus_form='auto')
-        self.assertEqual(form.focus_form, 'auto')
+        form = self._makeOne(schema)
+        self.assertEqual(form.focus_form, 'on')
     
-    def test_ctor_focus_form_manual(self):
+    def test_ctor_focus_form_on(self):
         schema = DummySchema()
         schema.children = [DummySchema()]
-        form = self._makeOne(schema, focus_form='manual')
-        self.assertEqual(form.focus_form, 'manual')
-
+        form = self._makeOne(schema, focus_form='on')
+        self.assertEqual(form.focus_form, 'on')
+    
     def test_ctor_focus_form_off(self):
         schema = DummySchema()
         schema.children = [DummySchema()]

--- a/deform/tests/test_form.py
+++ b/deform/tests/test_form.py
@@ -74,6 +74,30 @@ class TestForm(unittest.TestCase):
         form = self._makeOne(schema, autocomplete=False)
         self.assertEqual(form.autocomplete, 'off')
 
+    def test_ctor_focus_form_default(self):
+        schema = DummySchema()
+        schema.children = [DummySchema()]
+        form = self._makeOne(schema)
+        self.assertEqual(form.focus_form, 'auto')
+
+    def test_ctor_focus_form_auto(self):
+        schema = DummySchema()
+        schema.children = [DummySchema()]
+        form = self._makeOne(schema, focus_form='auto')
+        self.assertEqual(form.focus_form, 'auto')
+    
+    def test_ctor_focus_form_manual(self):
+        schema = DummySchema()
+        schema.children = [DummySchema()]
+        form = self._makeOne(schema, focus_form='manual')
+        self.assertEqual(form.focus_form, 'manual')
+
+    def test_ctor_focus_form_off(self):
+        schema = DummySchema()
+        schema.children = [DummySchema()]
+        form = self._makeOne(schema, focus_form='off')
+        self.assertEqual(form.focus_form, 'off')
+
 class TestIssues(unittest.TestCase):
 
     def test_issue_54(self):

--- a/deform/tests/test_functional.py
+++ b/deform/tests/test_functional.py
@@ -231,6 +231,21 @@ class IntSchema(colander.Schema):
         widget=deform.widget.RadioChoiceWidget(values=((0, 'zero'), (1, 'one')))
     )
 
+class AutofocusDefaultSchema(colander.Schema):
+    input1 = colander.SchemaNode(
+            colander.String(),
+            )
+
+class AutofocusSchema(colander.Schema):
+    input1 = colander.SchemaNode(
+            colander.String(),
+            )
+
+    input2 = colander.SchemaNode(
+            colander.String(),
+            autofocus='on'
+            )
+
 def remove_date(node, kw):
     if kw.get('nodates'): del node['date']
 
@@ -246,6 +261,24 @@ class TestSchemas(unittest.TestCase):
         value_index = result_with_checked.index('value="1"')
         checked_index = result_with_checked.index('checked="True"', value_index)
         self.assertTrue(checked_index > 0)
+
+    def test_autofocus_off(self):
+        schema = AutofocusSchema()
+        form = deform.Form(schema, buttons=('submit',), focus='off')
+        rendered = form.render()
+        self.assertFalse('autofocus="autofocus"' in rendered)
+
+    def test_autofocus_on(self):
+        schema = AutofocusSchema()
+        form = deform.Form(schema, buttons=('submit',), focus='on')
+        rendered = form.render()
+        self.assertTrue('autofocus="autofocus"' in rendered)
+
+    def test_autofocus_default(self):
+        schema = AutofocusDefaultSchema()
+        form = deform.Form(schema, buttons=('submit',))
+        rendered = form.render()
+        self.assertTrue('autofocus="autofocus"' in rendered)
 
 class TestDeferredFunction(unittest.TestCase):
     def test_it(self):


### PR DESCRIPTION
*Further to #244, #249 and #250* 

## Current behaviour
When a page is loaded, the first input of the first form is automatically focused.

## Problematic behaviour
If the first form is below the fold, web browsers automatically scroll down to the focused element. This means that, in some cases, a user may load a page and immediately be sent down to wherever the form is. This issue is particularly apparent on mobile/responsive pages.

## Proposed solution
Forms are to have an additional argument to determine if input focusing should be done automatically, manually or not at all. In the case of manual focusing, child input fields of the form will have an additional argument to determine if they are to receive focus.

Forms can take an additional argument when they are created.
`focus_form = 'auto' | 'manual' | 'off'`
This results in the form being rendered with a HTML attribute `data-deform-focus-form` with any of the above values.

The javascript function `focusFirstInput` will perform the following.

focus_form | action
---------------|--------------
'auto' | First input of the first form is focused
'manual' | First input with manual_focus set is focused
'off' | No focusing is done
omitted | Same as 'auto'

## Examples
### Default
```python
class SchemaInputDefault(colander.Schema):
    name = 'Default Input Focus'
    input = colander.SchemaNode(
    colander.String(),
    title = 'Input',
    missing = '')

class TestForm():
    def __init__(self, request):
        schema = SchemaInputDefault(validator=self.validate).bind(request=request)
        self.form = deform.Form(schema, buttons=(button,))
```
### Auto
```python
class SchemaInputAuto(colander.Schema):
    name = 'Auto Input Focus'
    input = colander.SchemaNode(
                  colander.String(),
                  title = 'Input',
                  missing = '')

class TestForm():
    def __init__(self, request):
        schema = SchemaInputAuto(validator=self.validate).bind(request=request)
        self.form = deform.Form(schema, buttons=(button,), focus_form='auto')
```
### Manual
```python
class SchemaInputManual(colander.Schema):
    name = 'Manual Input Focus'

    input1 = colander.SchemaNode(
                    colander.String(),
                    title = 'Input 1',
                    missing = '')
    
    input2 = colander.SchemaNode(
                    colander.String(),
                    title = 'Input 2 (Will be focused)',
                    missing = '',
                    manual_focus = 'on')
  
    input3 = colander.SchemaNode(
                    colander.String(),
                    title = 'Input 3',
                    missing = '')

class TestForm():
    def __init__(self, request):
        schema = SchemaInputManual(validator=self.validate).bind(request=request)
        self.form = deform.Form(schema, buttons=(button,), focus_form='manual')
```
### Off
```python
class SchemaInputOff(colander.Schema):
    name = 'No Input Focus'
    input = colander.SchemaNode(
                 colander.String(),
                 title = 'Input',
                 missing = '')

class TestForm():
    def __init__(self, request):
        schema = SchemaInputOff(validator=self.validate).bind(request=request)
        self.form = deform.Form(schema, buttons=(button,), focus_form='off')
```

## Results
* **Default behaviour is unchanged**
* On page load, the first input field of the first form receives focus (default)
* Any one input field can be chosen to receive focus
* Automatic focusing can be disabled on a per-form basis

----
Existing nose tests pass. Some basic tests were added (checking defaults etc). I'm not sure if this is a big enough change to warrant any extra examples on deformdemo, but I can put together a pull request for that if it might be worthwhile.