### PR TITLE
`alert-danger` is the right css class in BS3

### DIFF
--- a/deform/templates/mapping.pt
+++ b/deform/templates/mapping.pt
@@ -9,7 +9,7 @@
     <div class="panel-body">
 
       <div tal:condition="errormsg" 
-           class="clearfix alert alert-message error">
+           class="clearfix alert alert-danger">
         <p i18n:translate="">
            There was a problem with this section
         </p>


### PR DESCRIPTION
There's doesn't appear to be any Deform2Demo demo that can demonstrate this, but if you have a sub-mapping in your form that raises a `colander.Invalid` for that mapping it will display the error message at the top of the panel.  However, the CSS classes on that error message are incorrect and they're not highlighted in red like all the other error messages.  The proper CSS class for the error messages is "alert alert-danger" which is what is used in 'form.pt'.