### PR TITLE
select2.pt allow int for pk

### DIFF
--- a/deform/templates/select2.pt
+++ b/deform/templates/select2.pt
@@ -51,7 +51,7 @@
                 tal:attributes="label item.label">
         <option tal:repeat="(value, description) item.options"
                 tal:attributes="
-                selected (multiple and value in cstruct or value == cstruct) and 'selected';
+                selected (multiple and value in list(map(str, cstruct)) or value == list(map(str, cstruct))) and 'selected';
                 class css_class;
                 label field.widget.long_label_generator and description;
                 value value"
@@ -59,7 +59,7 @@
       </optgroup>
       <option tal:condition="not isinstance(item, optgroup_class)"
               tal:attributes="
-              selected (multiple and item[0] in cstruct or item[0] == cstruct) and 'selected';
+              selected (multiple and item[0] in list(map(str, cstruct)) or item[0] == list(map(str, cstruct))) and 'selected';
               class css_class;
               value item[0]">${item[1]}</option>
     </tal:loop>


### PR DESCRIPTION
primary key id's of type Integer are problematic. This allows both strings and integers to be used, which matches what the documentation says.