### PR TITLE
Reenable pypy3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ basepython =
     pypy: pypy
     py2: python2.7
     py3: python3.5
-#    pypy3: pypy3
+    pypy3: pypy3
 
 usedevelop = true
 


### PR DESCRIPTION
Disabling the interpreter causes [breakage on jenkins.pylonsproject.org](http://jenkins.pylonsproject.org/job/deform/295/console).

Current setuptools / pip / virtualenv versions build the enviornment cleanly.