### PR TITLE
- fix FileUploadWidget raises error if file is not provided (#339)

### DIFF
--- a/deform/tests/test_widget.py
+++ b/deform/tests/test_widget.py
@@ -1332,6 +1332,16 @@ class TestFileUploadWidget(unittest.TestCase):
         result = widget.deserialize(field, {})
         self.assertEqual(result, colander.null)
 
+    def test_deserialize_no_file_selected_no_previous_file_with_upload(self):
+        # If no upload is selected the browser sends back the name 'upload'.
+        # In pyramid under python3 we have {'upload': b''} as cstruct
+        schema = DummySchema()
+        field = DummyField(schema)
+        tmpstore = DummyTmpStore()
+        widget = self._makeOne(tmpstore)
+        result = widget.deserialize(field, {'upload': b''})
+        self.assertEqual(result, colander.null)
+
     def test_deserialize_no_file_selected_with_previous_file(self):
         schema = DummySchema()
         field = DummyField(schema)

--- a/deform/widget.py
+++ b/deform/widget.py
@@ -59,7 +59,7 @@ class _StrippedString(_PossiblyEmptyString):
 
 class _FieldStorage(SchemaType):
     def deserialize(self, node, cstruct):
-        if cstruct in (null, None, ''):
+        if cstruct in (null, None, b''):
             return null
         # weak attempt at duck-typing
         if not hasattr(cstruct, 'file'):


### PR DESCRIPTION
following tests are passing:
- py27
- py35
- pypy
- pypy3
- functional2

not tested:
- py33
- py34

tests failing:
- functional3 (on /datetimeinput with server error AttributeError: module 'iso8601.iso8601' has no attribute 'Utc')
