### PR TITLE
added css class ".form-text" to elements with ".help-block" class

### DIFF
--- a/deform/templates/mapping_item.pt
+++ b/deform/templates/mapping_item.pt
@@ -31,7 +31,7 @@
             tal:condition="input_append">${input_append}</span>
   </div>
 
-  <p class="help-block"
+  <p class="help-block form-text"
      tal:define="errstr 'error-%s' % field.oid"
      tal:repeat="msg field.error.messages()"
      i18n:translate=""
@@ -42,7 +42,7 @@
   </p>
 
   <p tal:condition="field.description and not field.widget.hidden"
-     class="help-block" >
+     class="help-block form-text" >
     ${field.description}
   </p>
 </div>

--- a/deform/templates/readonly/mapping_item.pt
+++ b/deform/templates/readonly/mapping_item.pt
@@ -31,7 +31,7 @@
             tal:condition="input_append">${input_append}</span>
   </div>
 
-  <p class="help-block"
+  <p class="help-block form-text"
      tal:define="errstr 'error-%s' % field.oid"
      tal:repeat="msg field.error.messages()"
      i18n:translate=""
@@ -42,7 +42,7 @@
   </p>
 
   <p tal:condition="field.description and not field.widget.hidden"
-     class="help-block" >
+     class="help-block form-text" >
     ${field.description}
   </p>
 </div>

--- a/deform/templates/sequence_item.pt
+++ b/deform/templates/sequence_item.pt
@@ -14,7 +14,7 @@
                 repeat="msg field.error.messages()">
       <p tal:condition="msg"
          id="${errstr if repeat.msg.index==0 else '%s-%s' % (errstr, repeat.msg.index)}"
-         class="${error_class} help-block"
+         class="${error_class} help-block form-text"
          i18n:translate="">${msg}</p>
     </tal:errors>
   </div>


### PR DESCRIPTION
With Bootstrap 4 the CSS class for help texts in forms [has changed][bs4]
from the previous ".help-block" class to ".form-text". This new css
class is added to the elements that have a ".help-block" class assigned
to them.

[bs4]: https://getbootstrap.com/docs/4.0/components/forms/#help-text