### PR TITLE
Fix fileupload under Python 3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,29 @@ addons:
   firefox: "43.0"
 
 matrix:
-    include:
-        - python: 2.7
-          env: TOXENV=py27
-        - python: 3.3
-          env: TOXENV=py33
-        - python: 3.4
-          env: TOXENV=py34
-        - python: 3.5
-          env: TOXENV=py35
-        - python: pypy
-          env: TOXENV=pypy
-        - python: 3.5
-          env: TOXENV=py2-cover,py3-cover,coverage
-        - python: 3.5
-          env: TOXENV=docs
-        - python: 2.7
-          env: TOXENV=functional
-        - python: 3.5
-          env: TOXENV=functional3
-#        - python: pypy3
-#          env: TOXENV=pypy3
+  include:
+    - python: "2.7"
+      env: TOXENV=py27
+    - python: "3.3"
+      env: TOXENV=py33
+    - python: "3.4"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "pypy"
+      env: TOXENV=pypy
+    - python: "pypy3"
+      env: TOXENV=pypy3
+    - python: "3.6"
+      env: TOXENV=py2-cover,py3-cover,coverage
+    - python: "3.6"
+      env: TOXENV=docs
+    - python: "2.7"
+      env: TOXENV=functional
+    - python: "3.6"
+      env: TOXENV=functional3
 
 install:
   - travis_retry pip install tox

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,9 @@
 
 - i18n cleanup https://github.com/Pylons/deform/pull/332
 
+- Fix bug in ``_FieldStorage`` under Python 3.x (issues #339 and #357).
+
+- Declare Python 3.6 compatibility and enable tests against Python 3.6 (all tests pass with no changes).
 
 2.0.4 (2017-02-11)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -128,4 +128,4 @@ Contributors
 - Martin Peeters 2016/10/22
 - Mikko Kolehmainen 2016/11/02
 - Gasper Vozel, 2016/09/15
-
+- Andreas Kaiser, 2018/01/09

--- a/deform/tests/test_widget.py
+++ b/deform/tests/test_widget.py
@@ -1332,6 +1332,16 @@ class TestFileUploadWidget(unittest.TestCase):
         result = widget.deserialize(field, {})
         self.assertEqual(result, colander.null)
 
+    def test_deserialize_no_file_selected_no_previous_file_with_upload(self):
+        # If no upload is selected the browser sends back the name 'upload'.
+        # In pyramid under python3 we have {'upload': b''} as cstruct
+        schema = DummySchema()
+        field = DummyField(schema)
+        tmpstore = DummyTmpStore()
+        widget = self._makeOne(tmpstore)
+        result = widget.deserialize(field, {'upload': b''})
+        self.assertEqual(result, colander.null)
+
     def test_deserialize_no_file_selected_with_previous_file(self):
         schema = DummySchema()
         field = DummyField(schema)

--- a/deform/widget.py
+++ b/deform/widget.py
@@ -59,7 +59,7 @@ class _StrippedString(_PossiblyEmptyString):
 
 class _FieldStorage(SchemaType):
     def deserialize(self, node, cstruct):
-        if cstruct in (null, None, b''): 
+        if cstruct in (null, None, b''):
             return null
         # weak attempt at duck-typing
         if not hasattr(cstruct, 'file'):

--- a/deform/widget.py
+++ b/deform/widget.py
@@ -59,7 +59,7 @@ class _StrippedString(_PossiblyEmptyString):
 
 class _FieldStorage(SchemaType):
     def deserialize(self, node, cstruct):
-        if cstruct in (null, None, ''):
+        if cstruct in (null, None, b''): 
             return null
         # weak attempt at duck-typing
         if not hasattr(cstruct, 'file'):

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ except:
 requires = [
     'Chameleon>=2.5.1',  # Markup class
     'colander>=1.0a1',  # cstruct_children/appstruct_children, Set
-    'iso8601',
+    'iso8601<=0.1.11',  # 0.1.12 has API changes that break functional3 tests
     'peppercorn>=0.3',  # rename operation type
     'translationstring>=1.0',  # add format mapping with %
     'zope.deprecation',

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setupkw = dict(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3,
+    py27,py33,py34,py35,py36,pypy,pypy3,
     docs,
     {py2,py3}-cover,coverage,
     functional, functional3
@@ -13,10 +13,11 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
     pypy: pypy
-    py2: python2.7
-    py3: python3.5
     pypy3: pypy3
+    py2: python2.7
+    py3: python3.6
 
 usedevelop = true
 
@@ -47,7 +48,7 @@ setenv =
     COVERAGE_FILE=.coverage.py3
 
 [testenv:coverage]
-basepython = python3.5
+basepython = python3.6
 commands =
     coverage erase
     coverage combine
@@ -59,7 +60,7 @@ setenv =
     COVERAGE_FILE=.coverage
 
 [testenv:docs]
-basepython = python3.5
+basepython = python3.6
 whitelist_externals = make
 commands =
     pip install deform[docs]
@@ -79,7 +80,7 @@ commands =
 [testenv:functional3]
 # Allow override test browser
 passenv = WEBDRIVER DISPLAY FIREFOX_PATH
-basepython = python3.5
+basepython = python3.6
 commands =
     pip install deform[testing,functional]
     ./run-selenium-tests.bash --with-flaky --max-runs=4 {posargs}


### PR DESCRIPTION
This PR supersedes / implements / fixes issues #339 and #357.

The corresponding test and the fix are copied from #357.  In addition the ``iso8601`` requirement is pinned to ``0.1.11``, because later versions include an API change that causes the ``functional3`` tests to fail (also see the discussion of #357).

With those 2 (unrelated) fixes all tests pass under all supported versions as well as under Python 3.6 and pypy3.  The respective versions are now enabled in both ``tox.ini`` and ``.travis.yml`` and Python 3.6 support is declared in ``setup.py``.