### PR TITLE
Revert "Fix unrelated issue that causes functional3 tests to fail (is…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ except:
 requires = [
     'Chameleon>=2.5.1',  # Markup class
     'colander>=1.0a1',  # cstruct_children/appstruct_children, Set
-    'iso8601<=0.1.11',  # 0.1.12 has API changes that break functional3 tests
+    'iso8601',
     'peppercorn>=0.3',  # rename operation type
     'translationstring>=1.0',  # add format mapping with %
     'zope.deprecation',


### PR DESCRIPTION
…o8601 0.1.12 has an API change)."

The iso8601 version pin can be removed considering the deformdemo tests
are ported to support a newer version of iso8601.

This reverts commit b1009e6386c1f513aa999251cdbf7b2f7222783b merged in #360.

Context: A deform update forces a downgrade of iso8601 over half a year after it has been released. While I applaud a new deform release, this is not a good idea: pinning a third-party library to an older version introduces a reversed API change. People may now rely on the new API implemented by iso8601.
I have made the deformdemo behavior that was originally broken by the iso8601 update compatible with older and newer versions of the dependency in https://github.com/Pylons/deformdemo/pull/51 . That PR is a requirement of this PR.

References: The original functional3 test failure was https://travis-ci.org/Pylons/deform/jobs/301033272.

