### PR TITLE
fix bad syntax with quotes

### DIFF
--- a/deform/locale/pt_BR/LC_MESSAGES/deform.po
+++ b/deform/locale/pt_BR/LC_MESSAGES/deform.po
@@ -126,7 +126,7 @@ msgstr "Senha não exibida"
 #: deform/tests/test_widget.py:1752
 #, python-format
 msgid "Yo ${subitem_title}"
-msgstr Yo ${subitem_title}""
+msgstr "Yo ${subitem_title}"
 
 #~ msgid "${value} is not iterable"
 #~ msgstr "Iterações não podem ser feitas em ${value}"


### PR DESCRIPTION
This PR partially resolves the inability to run functional tests.