### PR TITLE
HTML5 datetime input

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -138,3 +138,4 @@ Contributors
 - Krystian Rosiński, 2018/10/14
 - Sydo Luciani, 2020/05/16
 - Antony Oduor, 2020/06/18
+- John Haiducek, 2020/06/20

--- a/deform/templates/datetimeinput.pt
+++ b/deform/templates/datetimeinput.pt
@@ -2,7 +2,8 @@
       tal:omit-tag=""
       tal:define="oid oid|field.oid;
                   css_class css_class|field.widget.css_class;
-                  style style|field.widget.style;">
+                  style style|field.widget.style;
+		  type_name type_name|field.widget.type_name;">
   ${field.start_mapping()}
   <div class="row">
     <div class="col-xs-6"><div class="input-group">
@@ -27,10 +28,10 @@
    deform.addCallback(
      '${oid}',
      function(oid) {
-       if (!Modernizr.inputtypes['date'] || window.forceDateTimePolyfill){
+       if (!Modernizr.inputtypes['date'] || "${type_name}" != "datetime" || window.forceDateTimePolyfill){
          $('#' + oid + '-date').pickadate(${date_options_json});
        }
-       if (!Modernizr.inputtypes['date'] || window.forceDateTimePolyfill){
+       if (!Modernizr.inputtypes['date'] || "${type_name}" != "datetime" || window.forceDateTimePolyfill){
          $('#' + oid + '-time').pickatime(${time_options_json});
        }
      }

--- a/deform/templates/datetimeinput.pt
+++ b/deform/templates/datetimeinput.pt
@@ -3,7 +3,7 @@
       tal:define="oid oid|field.oid;
                   css_class css_class|field.widget.css_class;
                   style style|field.widget.style;
-		  type_name type_name|field.widget.type_name;">
+		    type_name type_name|field.widget.type_name;">
   ${field.start_mapping()}
   <div class="row">
     <div class="col-xs-6"><div class="input-group">

--- a/deform/templates/datetimeinput.pt
+++ b/deform/templates/datetimeinput.pt
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col-xs-6"><div class="input-group">
       <span class="input-group-addon" i18n:translate="">Date</span>
-      <input type="text" name="date" value="${date}"
+      <input type="date" name="date" value="${date}"
              class="span2 form-control ${css_class or ''} hasDatepicker"
              tal:attributes="style style;
              				 date_attributes|field.widget.date_attributes|{}"
@@ -15,7 +15,7 @@
     </div></div>
     <div class="col-xs-6"><div class="input-group">
       <span class="input-group-addon" i18n:translate="">Time</span>
-      <input type="text" name="time" value="${time}"
+      <input type="time" name="time" value="${time}"
              class="span2 form-control ${css_class or ''} hasDatepicker"
              tal:attributes="style style;
              				 time_attributes|field.widget.time_attributes|{}"
@@ -27,8 +27,12 @@
    deform.addCallback(
      '${oid}',
      function(oid) {
-       $('#' + oid + '-date').pickadate(${date_options_json});
-       $('#' + oid + '-time').pickatime(${time_options_json});
+       if (!Modernizr.inputtypes['date'] || window.forceDateTimePolyfill){
+         $('#' + oid + '-date').pickadate(${date_options_json});
+       }
+       if (!Modernizr.inputtypes['date'] || window.forceDateTimePolyfill){
+         $('#' + oid + '-time').pickatime(${time_options_json});
+       }
      }
    );
   </script>

--- a/deform/widget.py
+++ b/deform/widget.py
@@ -652,7 +652,7 @@ class DateTimeInputWidget(Widget):
     template = "datetimeinput"
     readonly_template = "readonly/datetimeinput"
     type_name = "datetime"
-    requirements = (("pickadate", None),)
+    requirements = (("modernizr",None),("pickadate", None),)
     default_date_options = (
         ("format", "yyyy-mm-dd"),
         ("selectMonths", True),

--- a/deform/widget.py
+++ b/deform/widget.py
@@ -652,7 +652,7 @@ class DateTimeInputWidget(Widget):
     template = "datetimeinput"
     readonly_template = "readonly/datetimeinput"
     type_name = "datetime"
-    requirements = (("modernizr",None),("pickadate", None),)
+    requirements = (("modernizr", None), ("pickadate", None))
     default_date_options = (
         ("format", "yyyy-mm-dd"),
         ("selectMonths", True),


### PR DESCRIPTION
This PR modifies the DateTimeInputWidget to use HTML5 date/time input types on browsers that support it.