### PR TITLE
Added a new "dev" member to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,10 @@ setupkw = dict(
         "testing": testing_extras,
         "docs": docs_extras,
         "functional": functional_testing_extra,
+        "dev": (
+            lint_extras + testing_extras + docs_extras +
+            functional_testing_extra + ["tox"]
+        )
     },
 )
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ lint_extras = [
 testing_extras = ["beautifulsoup4", "coverage", "flaky", "nose"]
 
 # Needed to run deformdemo tests
-functional_testing_extra = [
+functional_testing_extras = [
     "selenium>=3",
     "pyramid",
     "pygments",
@@ -101,13 +101,12 @@ setupkw = dict(
         "lint": lint_extras,
         "testing": testing_extras,
         "docs": docs_extras,
-        "functional": functional_testing_extra,
+        "functional": functional_testing_extras,
         "dev": (
             lint_extras
             + testing_extras
             + docs_extras
-            + functional_testing_extra
-            + ["tox"]
+            + functional_testing_extras
         ),
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -103,9 +103,12 @@ setupkw = dict(
         "docs": docs_extras,
         "functional": functional_testing_extra,
         "dev": (
-            lint_extras + testing_extras + docs_extras +
-            functional_testing_extra + ["tox"]
-        )
+            lint_extras
+            + testing_extras
+            + docs_extras
+            + functional_testing_extra
+            + ["tox"]
+        ),
     },
 )
 


### PR DESCRIPTION
This PR adds a new "dev" member to extras_require which combines the lint, testing, docs, and functional dependencies, plus tox. This allows a developer to install all the python modules required for testing, linting, and generating documentation with the command

    pip install -e ".[dev]"