### PR TITLE
Add boolean HTML attributes per Chameleon 3.8.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,15 @@
 2.0.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add boolean HTML attributes per Chameleon 3.8.0.
+
+  All checkboxes, radios, and selects that use boolean HTML attributes
+  (selected, checked, etc.) previously used `literal_false` and would drop any
+  `False` value from rendering as an HTML attribute. In Chameleon 3.8.0,
+  `literal_false` is removed and must instead use `boolean_attributes` to set
+  defaults.
+
+  See https://github.com/Pylons/deform/issues/417
 
 
 2.0.8 (2019-10-07)

--- a/deform/template.py
+++ b/deform/template.py
@@ -9,9 +9,31 @@ from translationstring import ChameleonTranslate
 from .exception import TemplateError
 
 
+BOOLEAN_HTML_ATTRS = frozenset(
+    [
+        # List of Boolean attributes in HTML that should be rendered in
+        # minimized form (e.g. <img ismap> rather than <img ismap="">)
+        # From http://www.w3.org/TR/xhtml1/#guidelines (C.10)
+        "compact",
+        "nowrap",
+        "ismap",
+        "declare",
+        "noshade",
+        "checked",
+        "disabled",
+        "readonly",
+        "multiple",
+        "selected",
+        "noresize",
+        "defer",
+    ]
+)
+
+
 class ZPTTemplateLoader(TemplateLoader):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("encoding", "utf-8")
+        kwargs.setdefault("boolean_attributes", BOOLEAN_HTML_ATTRS)
         super(ZPTTemplateLoader, self).__init__(*args, **kwargs)
 
     def load(self, filename, *args, **kwargs):

--- a/deform/tests/test_functional.py
+++ b/deform/tests/test_functional.py
@@ -71,7 +71,7 @@ class TestFunctional(unittest.TestCase):
         self.assertEqual(inputs[3]["name"], "title")
         self.assertEqual(inputs[3]["value"], "")
         self.assertEqual(inputs[4]["name"], "cool")
-        self.assertEqual(inputs[4].get("checked"), "True")
+        self.assertEqual(inputs[4].get("checked"), "checked")
         self.assertEqual(inputs[5]["name"], "__start__")
         self.assertEqual(inputs[5]["value"], "series:mapping")
         self.assertEqual(inputs[6]["name"], "name")
@@ -295,7 +295,7 @@ class TestSchemas(unittest.TestCase):
         result_with_checked = form.render({"int_field": 1})
         value_index = result_with_checked.index('value="1"')
         checked_index = result_with_checked.index(
-            'checked="True"', value_index
+            'checked="checked"', value_index
         )
         self.assertTrue(checked_index > 0)
 


### PR DESCRIPTION
All checkboxes, radios, and selects that use boolean HTML attributes (selected, checked, etc.) previously used `literal_false` and would drop any `False` value from rendering as an HTML attribute. In Chameleon 3.8.0, `literal_false` is removed and must instead use `boolean_attributes` to set defaults.

See #417