### PR TITLE
Fix deprecation warnings

### DIFF
--- a/deform/field.py
+++ b/deform/field.py
@@ -347,8 +347,8 @@ class Field(object):
             .encode("ascii", "ignore")
             .decode("ascii")
         )
-        css_class = re.sub("[^\w\s-]", "", css_class).strip().lower()  # noQA
-        css_class = re.sub("[-\s]+", "-", css_class)  # noQA
+        css_class = re.sub(r"[^\w\s-]", "", css_class).strip().lower()  # noQA
+        css_class = re.sub(r"[-\s]+", "-", css_class)  # noQA
         return "item-%s" % css_class
 
     def get_widget_requirements(self):


### PR DESCRIPTION
Fix incomplete character escaping
```
deform/field.py:350: DeprecationWarning: invalid escape sequence \w
deform/field.py:351: DeprecationWarning: invalid escape sequence \s
```