### PR TITLE
Add the `structure` keyword to the autocomplete template's options to…

### DIFF
--- a/deform/templates/autocomplete_input.pt
+++ b/deform/templates/autocomplete_input.pt
@@ -17,7 +17,7 @@
         deform.addCallback(
           '${field.oid}',
           function (oid) {
-              $('#' + oid).typeahead(${options});
+              $('#' + oid).typeahead(${structure:options});
               if("${autofocus}" == "autofocus") {
                 $('#' + oid).focus();
               }


### PR DESCRIPTION
… stop its encoding.

See https://github.com/Pylons/deformdemo/pull/16