### PR TITLE
update with bootstrap changes and i18n domain

### DIFF
--- a/deform/templates/readonly/password.pt
+++ b/deform/templates/readonly/password.pt
@@ -1,3 +1,5 @@
-<div i18n:domain="">
-  <em i18n:translate=""> Password not displayed. </em>
+<div i18n:domain="deform">
+  <p class="form-control-static deform-readonly-text"
+       id="${oid|field.oid}"
+       i18n:translate="">Password not displayed.</p>
 </div>


### PR DESCRIPTION
I think readonly/password.pt is supposed to be identical to
readonly/checked_password.pt so copied that over.  The original one
was missing an i18n domain and some newer bootstrap changes

(cherry picked from commit 1c185b08057171d862d94c8100b604be7f1728f6)