### PR TITLE
Support for Content-Security-Policy headers via nonce attribute of script/style tags

### DIFF
--- a/deform/field.py
+++ b/deform/field.py
@@ -2,6 +2,7 @@
 # Standard Library
 import itertools
 import re
+from typing import Optional
 import unicodedata
 import weakref
 
@@ -126,6 +127,29 @@ class Field(object):
             ``autofocus`` set to a true-ish value (``on``, ``True``, or
             ``autofocus``) will receive focus on page load. Default: ``None``.
 
+        script_nonce
+            Nonce (number-used-once) for use with ``<script>`` tags via the
+            HTTP Content-Security-Policy (CSP) header system. If the CSP header
+            requires that inline Javascript is tagged with a relevant nonce,
+            pass it here to apply this nonce to ``<script>`` tags only, or
+            via the ``nonce`` argument (if it should be applied to all tags
+            supporting nonces).
+
+        style_nonce
+            Nonce (number-used-once) for use with ``<style>`` tags via the
+            HTTP Content-Security-Policy (CSP) header system. If the CSP header
+            requires that inline Javascript is tagged with a relevant nonce,
+            pass it here to apply this nonce to ``<style>`` tags only, or
+            via the ``nonce`` argument (if it should be applied to all tags
+            supporting nonces).
+
+        nonce
+            Content-Security-Policy (CSP) nonce to be applied to all tags
+            supporting a ``nonce`` attribute, currently supported for
+            ``<script>`` and ``<style>``. See also ``script_nonce``,
+            ``style_nonce``. Specifying ``nonce`` overrides the more specific
+            options.
+
     *Constructor Arguments*
 
       ``renderer``, ``counter``, ``resource_registry`` and ``appstruct`` are
@@ -183,6 +207,9 @@ class Field(object):
         appstruct=colander.null,
         parent=None,
         autofocus=None,
+        script_nonce: str = None,
+        style_nonce: str = None,
+        nonce: str = None,
         **kw
     ):
         self.counter = counter or itertools.count()
@@ -199,6 +226,12 @@ class Field(object):
         if resource_registry is None:
             resource_registry = self.default_resource_registry
         self.renderer = renderer
+        if nonce:
+            self.script_nonce = nonce
+            self.style_nonce = nonce
+        else:
+            self.script_nonce = script_nonce
+            self.style_nonce = style_nonce
 
         # Parameters passed from parent field to child
         if "focus" in kw:
@@ -275,7 +308,7 @@ class Field(object):
             self.parent.found_first()
 
     @property
-    def parent(self):
+    def parent(self) -> Optional["Field"]:
         if self._parent is None:
             return None
         return self._parent()
@@ -924,3 +957,29 @@ class Field(object):
             name = self.name
         tag = '<input type="hidden" name="__end__" value="%s:rename"/>'
         return Markup(tag % (name,))
+
+    @property
+    def script_nonce_recursive(self) -> Optional[str]:
+        """
+        Returns the CSP nonce for ``<script>`` tags or, if ``self`` doesn't
+        have one, its parent (until we find one or reach the topmost
+        parent).
+        """
+        if self.script_nonce:
+            return self.script_nonce
+        if self.parent:
+            return self.parent.script_nonce_recursive
+        return None
+
+    @property
+    def style_nonce_recursive(self) -> Optional[str]:
+        """
+        Returns the CSP nonce for ``<style>`` tags or, if ``self`` doesn't
+        have one, its parent (until we find one or reach the topmost
+        parent).
+        """
+        if self.style_nonce:
+            return self.style_nonce
+        if self.parent:
+            return self.parent.style_nonce_recursive
+        return None

--- a/deform/templates/autocomplete_input.pt
+++ b/deform/templates/autocomplete_input.pt
@@ -13,7 +13,7 @@
                            autofocus autofocus;
                            attributes|field.widget.attributes|{};"
            id="${oid}"/>
-    <script tal:condition="field.widget.values" type="text/javascript">
+    <script tal:condition="field.widget.values" type="text/javascript" nonce="${field.script_nonce_recursive}">
         deform.addCallback(
           '${field.oid}',
           function (oid) {

--- a/deform/templates/checked_input.pt
+++ b/deform/templates/checked_input.pt
@@ -25,7 +25,7 @@
                            confirm_attributes|field.widget.confirm_attributes|{};"
            id="${oid}-confirm"/>
   </div>
-  <script tal:condition="field.widget.mask" type="text/javascript">
+  <script tal:condition="field.widget.mask" type="text/javascript" nonce="${field.script_nonce_recursive}">
    deform.addCallback(
      '${oid}',
      function (oid) {

--- a/deform/templates/dateinput.pt
+++ b/deform/templates/dateinput.pt
@@ -15,7 +15,7 @@
                          attributes|field.widget.attributes|{};"
          id="${oid}"/>
   ${field.end_mapping()}
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="${field.script_nonce_recursive}">
    deform.addCallback(
     '${oid}',
      function deform_cb(oid) {

--- a/deform/templates/datetimeinput.pt
+++ b/deform/templates/datetimeinput.pt
@@ -26,7 +26,7 @@
     </div></div>
   </div>
   ${field.end_mapping()}
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="${field.script_nonce_recursive}">
    deform.addCallback(
      '${oid}',
      function(oid) {

--- a/deform/templates/file_upload.pt
+++ b/deform/templates/file_upload.pt
@@ -11,7 +11,7 @@
          tal:condition="uid"
          type="hidden" name="uid" value="${uid}"/>
   ${field.end_mapping()}
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="${field.script_nonce_recursive}">
     deform.addCallback('${oid}', function (oid) {
       $('#' + oid).upload();
     });

--- a/deform/templates/form.pt
+++ b/deform/templates/form.pt
@@ -76,7 +76,7 @@
 
   </fieldset>
 
-  <script type="text/javascript" tal:condition="use_ajax">
+  <script type="text/javascript" tal:condition="use_ajax" nonce="${field.script_nonce_recursive}">
    deform.addCallback(
      '${formid}',
      function(oid) {

--- a/deform/templates/moneyinput.pt
+++ b/deform/templates/moneyinput.pt
@@ -12,7 +12,7 @@
                            autofocus autofocus;
                            attributes|field.widget.attributes|{};"
            id="${oid}"/>
-    <script type="text/javascript">
+    <script type="text/javascript" nonce="${field.script_nonce_recursive}">
       deform.addCallback(
          '${oid}',
          function (oid) {

--- a/deform/templates/richtext.pt
+++ b/deform/templates/richtext.pt
@@ -6,7 +6,7 @@
     i18n:domain="deform"
     tal:omit-tag="">
 
-    <style type="text/css">
+    <style type="text/css" nonce="${field.style_nonce_recursive}">
       .deform .tinymce-preload{
           border: 1px solid #CCC;
           height: 240px;
@@ -23,7 +23,7 @@
   <span id="${oid}-preload" class="tinymce-preload" 
         tal:condition="delayed_load and not field.error"
         tal:content="structure cstruct" />
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="${field.script_nonce_recursive}">
     (function($){
       deform.addCallback('${oid}', function(oid) {
         var options = {

--- a/deform/templates/select2.pt
+++ b/deform/templates/select2.pt
@@ -9,7 +9,7 @@
      autofocus autofocus|field.autofocus"
      tal:omit-tag="">
 
-   <style>
+   <style nonce="${field.style_nonce_recursive}">
 
      .select2-selection.form-control {
        padding: 0px 0px;
@@ -52,7 +52,7 @@
     </tal:loop>
   </select>
 
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="${field.script_nonce_recursive}">
    deform.addCallback(
      '${field.oid}',
      function(oid) {

--- a/deform/templates/selectize.pt
+++ b/deform/templates/selectize.pt
@@ -44,7 +44,7 @@
     </tal:loop>
   </select>
 
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="${field.script_nonce_recursive}">
     deform.addCallback(
       "${field.oid}",
       function(oid) {

--- a/deform/templates/sequence.pt
+++ b/deform/templates/sequence.pt
@@ -13,7 +13,7 @@
      class="deform-seq"
      id="${oid}">
 
-  <style>
+  <style nonce="${field.style_nonce_recursive}">
     body.dragging, body.dragging * {
       cursor: move !important;
     }
@@ -60,7 +60,7 @@
         <small id="${field.oid}-addtext">${add_subitem_text}</small>
       </a>
 
-      <script type="text/javascript">
+      <script type="text/javascript" nonce="${field.script_nonce_recursive}">
        deform.addCallback(
          '${field.oid}',
          function(oid) {

--- a/deform/templates/textinput.pt
+++ b/deform/templates/textinput.pt
@@ -13,7 +13,7 @@
                            autofocus autofocus;
                            attributes|field.widget.attributes|{};"
            id="${oid}"/>
-    <script tal:condition="mask" type="text/javascript">
+    <script tal:condition="mask" type="text/javascript" nonce="${field.script_nonce_recursive}">
       deform.addCallback(
          '${oid}',
          function (oid) {

--- a/deform/templates/timeinput.pt
+++ b/deform/templates/timeinput.pt
@@ -16,7 +16,7 @@
                          attributes|field.widget.attributes|{};"
          id="${oid}"/>
   ${field.end_mapping()}
-  <script type="text/javascript">
+  <script type="text/javascript" nonce="${field.script_nonce_recursive}">
     deform.addCallback(
       '${oid}',
       function(oid) {

--- a/deform/tests/test_field.py
+++ b/deform/tests/test_field.py
@@ -766,6 +766,32 @@ class TestField(unittest.TestCase):
         self.assertEqual(root.children[0].have_first_input, True)
         self.assertEqual(root.have_first_input, True)
 
+    def test_nonces(self) -> None:
+        # Deform
+        from deform.field import Field
+
+        nonce1 = "dummy_nonce_1"
+        nonce2 = "dummy_nonce_2"
+        nonce3 = "dummy_nonce_3"
+        schema = DummySchema()
+
+        root1 = self._makeOne(schema, renderer="abc",
+                              script_nonce=nonce1, style_nonce=nonce2)
+        child1 = Field(schema, name="child1", parent=root1)
+        root1.children = [child1]
+        self.assertEqual(root1.script_nonce_recursive, nonce1)
+        self.assertEqual(root1.style_nonce_recursive, nonce2)
+        self.assertEqual(child1.script_nonce_recursive, nonce1)
+        self.assertEqual(child1.style_nonce_recursive, nonce2)
+
+        root2 = self._makeOne(schema, renderer="abc", nonce=nonce3)
+        child2 = Field(schema, name="child2", parent=root2)
+        root2.children = [child2]
+        self.assertEqual(root2.script_nonce_recursive, nonce3)
+        self.assertEqual(root2.style_nonce_recursive, nonce3)
+        self.assertEqual(child2.script_nonce_recursive, nonce3)
+        self.assertEqual(child2.style_nonce_recursive, nonce3)
+
 
 class DummyField(object):
     oid = "oid"

--- a/deform/tests/test_widget.py
+++ b/deform/tests/test_widget.py
@@ -2056,6 +2056,87 @@ class TestSequenceWidget(unittest.TestCase):
             colander.Invalid, widget.deserialize, field, {"x": "123"}
         )
 
+    def test_nonce_present_render(self):
+        """
+        ``SequenceWidget`` uses both ``<script>`` and ``<style>`` so can be
+        used to test HTTP Content-Security-Policy nonces.
+        """
+        from bs4 import BeautifulSoup
+        from colander import MappingSchema, SchemaNode, SequenceSchema, String
+        from deform.form import Form
+        from deform.template import default_renderer
+        from deform.widget import SequenceWidget, TextInputWidget
+
+        class TestTextSchema(MappingSchema):
+            text_value = SchemaNode(
+                String(),
+                widget=TextInputWidget(),
+                translate=None
+            )
+
+        class TestSequenceSchema(SequenceSchema):
+            text_sequence = TestTextSchema(
+                widget=SequenceWidget(),
+                translate=None
+            )
+
+        test_nonce_script = "dummy_script_nonce_value"
+        test_nonce_script_tag = f'nonce="{test_nonce_script}"'
+        test_nonce_style = "dummy_style_nonce_value"
+        test_nonce_style_tag = f'nonce="{test_nonce_style}"'
+        schema = TestSequenceSchema()
+        form = Form(
+            schema,
+            script_nonce=test_nonce_script,
+            style_nonce=test_nonce_style,
+            renderer=default_renderer
+        )
+        content = form.render()
+        html = f"<html><body>{content}</body></html>"
+        parsed_html = BeautifulSoup(html, features="html.parser")
+        script_tags = parsed_html.body.find('script')
+        style_tags = parsed_html.body.find('style')
+        # import pdb; pdb.set_trace()
+        self.assertTrue(test_nonce_script_tag in str(script_tags))
+        self.assertTrue(test_nonce_style_tag in str(style_tags))
+
+    def test_nonce_absent_render(self):
+        """
+        No CSP nonce used. Nonce attributes should not be emitted.
+        """
+        from bs4 import BeautifulSoup
+        from colander import MappingSchema, SchemaNode, SequenceSchema, String
+        from deform.form import Form
+        from deform.template import default_renderer
+        from deform.widget import SequenceWidget, TextInputWidget
+
+        class TestTextSchema(MappingSchema):
+            text_value = SchemaNode(
+                String(),
+                widget=TextInputWidget(),
+                translate=None
+            )
+
+        class TestSequenceSchema(SequenceSchema):
+            text_sequence = TestTextSchema(
+                widget=SequenceWidget(),
+                translate=None
+            )
+
+        nonce_attr = 'nonce='
+        schema = TestSequenceSchema()
+        form = Form(schema, renderer=default_renderer)
+        content = form.render()
+        html = f"<html><body>{content}</body></html>"
+        parsed_html = BeautifulSoup(html, features="html.parser")
+        script_tags = parsed_html.body.find('script')
+        style_tags = parsed_html.body.find('style')
+        # Chameleon/Zope/ZPT strips out the tags if the content is blank.
+        # So there will be no "nonce" attr at all.
+        # import pdb; pdb.set_trace()
+        self.assertFalse(nonce_attr in str(script_tags))
+        self.assertFalse(nonce_attr in str(style_tags))
+
 
 class TestFormWidget(unittest.TestCase):
     def _makeOne(self, **kw):


### PR DESCRIPTION
Suggested fix for https://github.com/Pylons/deform/issues/512.

(Code style uses Python 3 type hinting, since ``setup.py`` has Python 3.6 as the minimum version.)