### PR TITLE
Prevent browser from auto-filling CheckedPasswordWidget

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -70,6 +70,9 @@ Features and Fixes
   [stevepiercy]
   https://github.com/Pylons/deform/issues/260
 
+- Avoid autocompleting passwords on ``CheckedPasswordWidget``
+  [JocelynDelalande]
+
 - Optionally bypass the resource registry and specify a resource as a dict
   where its keys are the type of asset (``"js"`` or ``"css"``) and its values
   are either a string or a list of strings of paths to assets on disk.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -144,3 +144,4 @@ Contributors
 - Stanisław Pitucha, 2020/06/30
 - Lele Gaifax, 2020/08/22
 - Geoffrey T. Dairiki, 2020/08/24
+- Jocelyn Delalande, 2021/05/05

--- a/deform/templates/checked_password.pt
+++ b/deform/templates/checked_password.pt
@@ -7,6 +7,7 @@
 ${field.start_mapping()}
 <div>
   <input type="password"
+         autocomplete="new-password"
          name="${name}"
          value="${field.widget.redisplay and cstruct or ''}"
          tal:attributes="class string: form-control ${css_class or ''};
@@ -19,6 +20,7 @@ ${field.start_mapping()}
 </div>
 <div>
   <input type="password"
+         autocomplete="new-password"
          name="${name}-confirm"
          value="${field.widget.redisplay and confirm or ''}"
          tal:attributes="class string: form-control ${css_class or ''};


### PR DESCRIPTION
Browser support is incomplete, but better than nothing :).

See https://caniuse.com/mdn-html_global_attributes_autocomplete_new-password