### PR TITLE
Fix bug when CSRF token does not appear in a form

### DIFF
--- a/deform/schema.py
+++ b/deform/schema.py
@@ -1,6 +1,7 @@
 """Schema."""
 # Pyramid
 import colander
+from pyramid.csrf import get_csrf_token
 
 # Deform
 from deform.i18n import _
@@ -27,7 +28,7 @@ default_widget_makers = {
 
 @colander.deferred
 def deferred_csrf_value(node, kw):
-    return kw["request"].session.get_csrf_token()
+    return get_csrf_token(kw["request"])
 
 
 class FileData(object):


### PR DESCRIPTION
This fixes a bug when  csrf_token value appears empty in a form in the case when a schema has been created before creating a session factory, i.e. ..input type="hidden" name="csrf_token" value="" id=.... Also, calling the function deferred_csrf_value() directly produced an error message "No session factory registered (see the Sessions chapter of the Pyramid documentation)". My fix calls the safe function get_csrf_token() which always returns a token, creates it if neccessary.