### PR TITLE
Install tox in development virtual environment

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -62,7 +62,7 @@ We use [tox](https://tox.readthedocs.io/en/latest/install.html) to:
 Install `tox` either in your path or locally.
 The examples below assume that `tox` was installed with:
 
-    python3 -m pip install tox
+    python3 -m pip install --user tox
     export TOX=$(python3 -c 'import site; print(site.USER_BASE + "/bin")')/tox
 
 See `tox.ini` at the root of the repository for currently supported environments.

--- a/contributing.md
+++ b/contributing.md
@@ -62,8 +62,8 @@ We use [tox](https://tox.readthedocs.io/en/latest/install.html) to:
 Install `tox` either in your path or locally.
 The examples below assume that `tox` was installed with:
 
-    $VENV/bin/pip3 install --user tox
-    export TOX=$(python3 -c 'import site; print(site.USER_BASE + "/bin")')/tox
+    $VENV/bin/pip3 install tox
+    export TOX=~/projects/deform/env/bin/tox
 
 See `tox.ini` at the root of the repository for currently supported environments.
 

--- a/contributing.md
+++ b/contributing.md
@@ -62,8 +62,8 @@ We use [tox](https://tox.readthedocs.io/en/latest/install.html) to:
 Install `tox` either in your path or locally.
 The examples below assume that `tox` was installed with:
 
-    $VENV/bin/pip3 install tox
-    export TOX=~/projects/deform/env/bin/tox
+    python3 -m pip install tox
+    export TOX=$(python3 -c 'import site; print(site.USER_BASE + "/bin")')/tox
 
 See `tox.ini` at the root of the repository for currently supported environments.
 


### PR DESCRIPTION
Fix the following error:

```
krystian@debian:~/projects/deform$ $VENV/bin/pip3 install --user tox
ERROR: Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
```