### PR TITLE
docs: Fix a few typos

### DIFF
--- a/deform/widget.py
+++ b/deform/widget.py
@@ -2019,7 +2019,7 @@ class TextAreaCSVWidget(Widget):
     quoting = csv.QUOTE_MINIMAL
 
     def serialize(self, field, cstruct, **kw):
-        # XXX make cols and rows overrideable
+        # XXX make cols and rows overridable
         if cstruct is null:
             cstruct = []
         textrows = getattr(field, "unparseable", None)
@@ -2096,7 +2096,7 @@ class TextInputCSVWidget(Widget):
     mask_placeholder = "_"
 
     def serialize(self, field, cstruct, **kw):
-        # XXX make size and mask overrideable
+        # XXX make size and mask overridable
         if cstruct is null:
             cstruct = ""
         textrow = getattr(field, "unparseable", None)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -236,7 +236,7 @@ epub_uid = epub_title
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 


### PR DESCRIPTION
There are small typos in:
- deform/widget.py
- docs/conf.py

Fixes:
- Should read `overridable` rather than `overrideable`.
- Should read `that` rather than `shat`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md