### PR TITLE
Add .mailmap and update my CONTRIBUTORS.txt entry

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Delta Regeer <xistence@0x58.com> <bertjw@regeer.org>
+Delta Regeer <xistence@0x58.com> <xistence@0x58.com>

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -123,7 +123,7 @@ Contributors
 - Cédric Messiant, 2014/06/27
 - Mike Dunne, 2015/05/08
 - Josip Delić, 2016/02/16
-- Bert JW Regeer, 2016/02/16
+- Delta Regeer, 2016/02/16
 - Steve Piercy, 2016/02/19
 - Mikko Ohtamaa 2016/06/01
 - Martin Peeters 2016/10/22

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include lingua.ini tox.ini
 include i18n.sh run-selenium-tests.bash
 include pyproject.toml
 include .coveragerc .isort.cfg .flake8
+include .mailmap
 exclude .readthedocs.yaml
 recursive-include deform/static *.js
 


### PR DESCRIPTION
Adds a `.mailmap` so my commits resolve to my current name and email. It maps
by commit email, which covers every historical variant. Display-only — the
commit objects themselves are unchanged.

Also updates my `CONTRIBUTORS.txt` entry to match.
`.mailmap` is added to `MANIFEST.in` so check-manifest stays happy.